### PR TITLE
Revert ConfigurationExtensions version

### DIFF
--- a/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
+++ b/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.14.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.10" />
     <PackageReference Include="MinVer" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
+++ b/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
@@ -43,8 +43,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.14.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.10" />
     <PackageReference Include="MinVer" Version="2.3.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This issue resolves an issue where a version of `Microsoft.Extensions.Options.ConfigurationExtensions` was incompatible with the v3 Azure Functions host. The fix is to change the version from `5.0.0` to `3.1.10`.

Fixes #23 
