### PR TITLE
IItem abstraction to allow for custom base item classes

### DIFF
--- a/Microsoft.Azure.CosmosRepository/src/Attributes/PartitionKeyPathAttribute.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Attributes/PartitionKeyPathAttribute.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Azure.CosmosRepository.Attributes
 {
     /// <summary>
     /// The partition key path attribute exposes the ability to declaratively
-    /// specify an <see cref="Item"/> partition key path. This attribute should be used in
-    /// conjunction with a <see cref="Newtonsoft.Json.JsonPropertyAttribute"/> on the <see cref="Item"/> property
+    /// specify an <see cref="IItem"/> partition key path. This attribute should be used in
+    /// conjunction with a <see cref="Newtonsoft.Json.JsonPropertyAttribute"/> on the <see cref="IItem"/> property
     /// whose value will act as the partition key. Partition key paths should start with "/",
     /// for example "/partition". For more information,
     /// see https://docs.microsoft.com/azure/cosmos-db/partitioning-overview.
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.CosmosRepository.Attributes
         public string Path { get; } = "/id";
 
         /// <summary>
-        /// Constructor accepting the <paramref name="path"/> of the partition key for a given <see cref="Item"/>.
+        /// Constructor accepting the <paramref name="path"/> of the partition key for a given <see cref="IItem"/>.
         /// </summary>
         /// <param name="path"></param>
         public PartitionKeyPathAttribute(string path) =>

--- a/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
+++ b/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
@@ -19,7 +19,7 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.CosmosRepository
 {
     /// <inheritdoc/>
-    internal class DefaultRepository<TItem> : IRepository<TItem> where TItem : Item
+    internal class DefaultRepository<TItem> : IRepository<TItem> where TItem : IItem
     {
         readonly ICosmosContainerProvider<TItem> _containerProvider;
         readonly IOptionsMonitor<RepositoryOptions> _optionsMonitor;
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.CosmosRepository
 
             TryLogDebugDetails(_logger, () => $"Read: {JsonConvert.SerializeObject(item)}");
 
-            return string.IsNullOrEmpty(item.Type) || item.Type == typeof(TItem).Name ? item : null;
+            return string.IsNullOrEmpty(item.Type) || item.Type == typeof(TItem).Name ? item : default;
         }
 
         /// <inheritdoc/>

--- a/Microsoft.Azure.CosmosRepository/src/DefaultRepositoryFactory.cs
+++ b/Microsoft.Azure.CosmosRepository/src/DefaultRepositoryFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.CosmosRepository
 
         /// <inheritdoc/>
         public IRepository<TItem> RepositoryOf<TItem>()
-            where TItem : Item =>
+            where TItem : IItem =>
             _serviceProvider.GetRequiredService<IRepository<TItem>>();
     }
 }

--- a/Microsoft.Azure.CosmosRepository/src/IItem.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IItem.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.CosmosRepository
+{
+    /// <summary>
+    /// The base interface used for all repository object or object graphs.
+    /// </summary>
+    public interface IItem
+    {
+        /// <summary>
+        /// Gets or sets the item's globally unique identifier.
+        /// </summary>
+        string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item's type name.
+        /// </summary>
+        string Type { get; set; }
+
+        /// <summary>
+        /// Gets the item's PartitionKey.
+        /// </summary>
+        PartitionKey PartitionKey { get; }
+    }
+}

--- a/Microsoft.Azure.CosmosRepository/src/IRepository.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IRepository.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.CosmosRepository
     /// This is the repository interface for any implementation of
     /// <typeparamref name="TItem"/>, exposing asynchronous C.R.U.D. functionality.
     /// </summary>
-    /// <typeparam name="TItem">The <see cref="Item"/> subclass type.</typeparam>
+    /// <typeparam name="TItem">The <see cref="IItem"/> subclass type.</typeparam>
     /// <example>
-    /// With DI, use .ctor injection to require any subclass of <see cref="Item"/>:
+    /// With DI, use .ctor injection to require any subclass of <see cref="IItem"/>:
     /// <code language="c#">
     /// <![CDATA[
     /// public class ConsumingService
@@ -29,34 +29,34 @@ namespace Microsoft.Azure.CosmosRepository
     /// ]]>
     /// </code>
     /// </example>
-    public interface IRepository<TItem> where TItem : Item
+    public interface IRepository<TItem> where TItem : IItem
     {
         /// <summary>
-        /// Gets the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
+        /// Gets the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <remarks>
         /// If the typeof(<typeparamref name="TItem"/>).Name differs from the item.Type you're attempting to retrieve, null is returned.
         /// </remarks>
         /// <param name="id">The string identifier.</param>
-        /// <param name="partitionKeyValue">The partition key value if different than the <see cref="Item.Id"/>.</param>
+        /// <param name="partitionKeyValue">The partition key value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> GetAsync(string id, string partitionKeyValue = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
+        /// Gets the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <remarks>
         /// If the typeof(<typeparamref name="TItem"/>).Name differs from the item.Type you're attempting to retrieve, null is returned.
         /// </remarks>
         /// <param name="id">The string identifier.</param>
-        /// <param name="partitionKey">The <see cref="PartitionKey"/> value if different than the <see cref="Item.Id"/>.</param>
+        /// <param name="partitionKey">The <see cref="PartitionKey"/> value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> GetAsync(string id, PartitionKey partitionKey, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="Item"/>
+        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="IItem"/>
         /// subclasses that match the given <paramref name="predicate"/>.
         /// </summary>
         /// <remarks>
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.CosmosRepository
         ValueTask<IEnumerable<TItem>> GetAsync(Expression<Func<TItem, bool>> predicate, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="Item" />
+        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="IItem" />
         /// by the given Cosmos SQL query
         /// </summary>
         /// <param name="query">The Cosmos SQL query</param>
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.CosmosRepository
         ValueTask<IEnumerable<TItem>> GetByQueryAsync(string query, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="Item" />
+        /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="IItem" />
         /// by the given Cosmos QueryDefinition
         /// </summary>
         /// <param name="queryDefinition"></param>
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="value">The item value to create.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> CreateAsync(TItem value, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="value">The item value to update.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="Item"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> UpdateAsync(TItem value, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// Deletes the cosmos object that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <param name="id">The string identifier.</param>
-        /// <param name="partitionKeyValue">The partition key value if different than the <see cref="Item.Id"/>.</param>
+        /// <param name="partitionKeyValue">The partition key value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
         /// <returns>A <see cref="ValueTask"/> representing the asynchronous delete operation.</returns>
         ValueTask DeleteAsync(string id, string partitionKeyValue = null, CancellationToken cancellationToken = default);
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// Deletes the cosmos object that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <param name="id">The string identifier.</param>
-        /// <param name="partitionKey">The <see cref="PartitionKey"/> value if different than the <see cref="Item.Id"/>.</param>
+        /// <param name="partitionKey">The <see cref="PartitionKey"/> value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
         /// <returns>A <see cref="ValueTask"/> representing the asynchronous delete operation.</returns>
         ValueTask DeleteAsync(string id, PartitionKey partitionKey, CancellationToken cancellationToken = default);

--- a/Microsoft.Azure.CosmosRepository/src/IRepository.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IRepository.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.CosmosRepository
     /// This is the repository interface for any implementation of
     /// <typeparamref name="TItem"/>, exposing asynchronous C.R.U.D. functionality.
     /// </summary>
-    /// <typeparam name="TItem">The <see cref="IItem"/> subclass type.</typeparam>
+    /// <typeparam name="TItem">The <see cref="IItem"/> implementation class type.</typeparam>
     /// <example>
-    /// With DI, use .ctor injection to require any subclass of <see cref="IItem"/>:
+    /// With DI, use .ctor injection to require any implementation of <see cref="IItem"/>:
     /// <code language="c#">
     /// <![CDATA[
     /// public class ConsumingService
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.CosmosRepository
     public interface IRepository<TItem> where TItem : IItem
     {
         /// <summary>
-        /// Gets the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
+        /// Gets the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <remarks>
         /// If the typeof(<typeparamref name="TItem"/>).Name differs from the item.Type you're attempting to retrieve, null is returned.
@@ -40,11 +40,11 @@ namespace Microsoft.Azure.CosmosRepository
         /// <param name="id">The string identifier.</param>
         /// <param name="partitionKeyValue">The partition key value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> GetAsync(string id, string partitionKeyValue = null, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
+        /// Gets the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/> that corresponds to the given <paramref name="id"/>.
         /// </summary>
         /// <remarks>
         /// If the typeof(<typeparamref name="TItem"/>).Name differs from the item.Type you're attempting to retrieve, null is returned.
@@ -52,12 +52,12 @@ namespace Microsoft.Azure.CosmosRepository
         /// <param name="id">The string identifier.</param>
         /// <param name="partitionKey">The <see cref="PartitionKey"/> value if different than the <see cref="IItem.Id"/>.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> GetAsync(string id, PartitionKey partitionKey, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets an <see cref="IEnumerable{TItem}"/> collection of <see cref="IItem"/>
-        /// subclasses that match the given <paramref name="predicate"/>.
+        /// implementation classes that match the given <paramref name="predicate"/>.
         /// </summary>
         /// <remarks>
         /// If the typeof(<typeparamref name="TItem"/>).Name differs from the item.Type you're attempting to retrieve, the item is not returned.
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="value">The item value to create.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> CreateAsync(TItem value, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="value">The item value to update.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
-        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> subclass instance as a <typeparamref name="TItem"/>.</returns>
+        /// <returns>A <see cref="ValueTask{TItem}"/> representing the <see cref="IItem"/> implementation class instance as a <typeparamref name="TItem"/>.</returns>
         ValueTask<TItem> UpdateAsync(TItem value, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/Microsoft.Azure.CosmosRepository/src/IRepositoryFactory.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IRepositoryFactory.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <typeparam name="TItem">The item type that corresponds to the respoitory.</typeparam>
         /// <returns>An <see cref="IRepository{TItem}"/> of <typeparamref name="TItem"/>.</returns>
-        IRepository<TItem> RepositoryOf<TItem>() where TItem : Item;
+        IRepository<TItem> RepositoryOf<TItem>() where TItem : IItem;
     }
 }

--- a/Microsoft.Azure.CosmosRepository/src/Item.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Item.cs
@@ -9,24 +9,6 @@ using System;
 namespace Microsoft.Azure.CosmosRepository
 {
     /// <summary>
-    /// The base interface used for all repository object or object graphs.
-    /// </summary>
-    public interface IItem
-    {
-        /// <summary>
-        /// Gets or sets the item's globally unique identifier.
-        /// </summary>
-        string Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the item's type name.
-        /// </summary>
-        string Type { get; set; }
-
-        internal PartitionKey PartitionKey { get; }
-    }
-
-    /// <summary>
     /// A base helper class that implements IItem
     /// </summary>
     /// <example>
@@ -66,6 +48,10 @@ namespace Microsoft.Azure.CosmosRepository
         [JsonProperty("type")]
         public string Type { get; set; }
 
+        /// <summary>
+        /// Gets the PartitionKey based on <see cref="GetPartitionKeyValue"/>.
+        /// Implemented explicitly to keep out of Item API
+        /// </summary>
         PartitionKey IItem.PartitionKey => new PartitionKey(GetPartitionKeyValue());
 
         /// <summary>

--- a/Microsoft.Azure.CosmosRepository/src/Item.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Item.cs
@@ -68,5 +68,4 @@ namespace Microsoft.Azure.CosmosRepository
         /// <returns>The <see cref="Item.Id"/> unless overridden by the subclass.</returns>
         protected virtual string GetPartitionKeyValue() => Id;
     }
-
 }

--- a/Microsoft.Azure.CosmosRepository/src/Item.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Item.cs
@@ -9,7 +9,25 @@ using System;
 namespace Microsoft.Azure.CosmosRepository
 {
     /// <summary>
-    /// The base item used for all repository object or object graphs.
+    /// The base interface used for all repository object or object graphs.
+    /// </summary>
+    public interface IItem
+    {
+        /// <summary>
+        /// Gets or sets the item's globally unique identifier.
+        /// </summary>
+        string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the item's type name.
+        /// </summary>
+        string Type { get; set; }
+
+        internal PartitionKey PartitionKey { get; }
+    }
+
+    /// <summary>
+    /// A base helper class that implements IItem
     /// </summary>
     /// <example>
     /// Here is an example subclass item, which adds several properties:
@@ -31,7 +49,7 @@ namespace Microsoft.Azure.CosmosRepository
     /// ]]>
     /// </code>
     /// </example>
-    public abstract class Item
+    public abstract class Item : IItem
     {
         /// <summary>
         /// Gets or sets the item's globally unique identifier.
@@ -48,7 +66,7 @@ namespace Microsoft.Azure.CosmosRepository
         [JsonProperty("type")]
         public string Type { get; set; }
 
-        internal PartitionKey PartitionKey => new PartitionKey(GetPartitionKeyValue());
+        PartitionKey IItem.PartitionKey => new PartitionKey(GetPartitionKeyValue());
 
         /// <summary>
         /// Default constructor, assigns type name to <see cref="Type"/> property.
@@ -64,4 +82,5 @@ namespace Microsoft.Azure.CosmosRepository
         /// <returns>The <see cref="Item.Id"/> unless overridden by the subclass.</returns>
         protected virtual string GetPartitionKeyValue() => Id;
     }
+
 }

--- a/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
+++ b/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Product>IEvangelist Azure Cosmos Repository</Product>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <Description>This client library enables client applications to connect to Azure Cosmos via a repository pattern around the official Azure Cosmos .NET SDK. Azure Cosmos is a globally distributed, multi-model database service. For more information, refer to http://azure.microsoft.com/services/cosmos-db/. </Description>
     <Copyright>Copyright © IEvangelist. All rights reserved. Licensed under the MIT License.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
+++ b/Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <Company>Microsoft Corporation</Company>
     <Product>IEvangelist Azure Cosmos Repository</Product>
-    <TargetFramework>netstandard2.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>This client library enables client applications to connect to Azure Cosmos via a repository pattern around the official Azure Cosmos .NET SDK. Azure Cosmos is a globally distributed, multi-model database service. For more information, refer to http://azure.microsoft.com/services/cosmos-db/. </Description>
     <Copyright>Copyright © IEvangelist. All rights reserved. Licensed under the MIT License.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosContainerProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosContainerProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers
 {
     /// <inheritdoc/>
     class DefaultCosmosContainerProvider<TItem>
-        : ICosmosContainerProvider<TItem> where TItem : Item
+        : ICosmosContainerProvider<TItem> where TItem : IItem
     {
         readonly Lazy<Task<Container>> _lazyContainer;
         readonly RepositoryOptions _options;

--- a/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosPartitionKeyPathProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosPartitionKeyPathProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers
             new ConcurrentDictionary<Type, string>();
 
         /// <inheritdoc />
-        public string GetPartitionKeyPath<TItem>() where TItem : Item =>
+        public string GetPartitionKeyPath<TItem>() where TItem : IItem =>
             _partionKeyNameMap.GetOrAdd(typeof(TItem), GetPartitionKeyNameFactory);
 
         static string GetPartitionKeyNameFactory(Type type)

--- a/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosContainerProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosContainerProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers
     /// The cosmos container provider exposes a means of providing
     /// an instance to the configured <see cref="Container"/> object.
     /// </summary>
-    interface ICosmosContainerProvider<TItem> where TItem : Item
+    interface ICosmosContainerProvider<TItem> where TItem : IItem
     {
         /// <summary>
         /// Asynchronously gets the configured <see cref="Container"/> instance that corresponds to the 

--- a/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosPartitionKeyPathProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosPartitionKeyPathProvider.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers
 {
     /// <summary>
     /// The cosmos partition key path provider exposes the ability 
-    /// to get an <see cref="Item"/>'s partition key path.
+    /// to get an <see cref="IItem"/>'s partition key path.
     /// </summary>
     interface ICosmosPartitionKeyPathProvider
     {
@@ -14,6 +14,6 @@ namespace Microsoft.Azure.CosmosRepository.Providers
         /// </summary>
         /// <typeparam name="TItem">The item for which the partition key path corresponds.</typeparam>
         /// <returns>A string value representing the partition key path, i.e.; "/partion"</returns>
-        string GetPartitionKeyPath<TItem>() where TItem : Item;
+        string GetPartitionKeyPath<TItem>() where TItem : IItem;
     }
 }

--- a/Microsoft.Azure.CosmosRepository/test/DefaultRepositoryFactoryTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/DefaultRepositoryFactoryTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.CosmosRepository;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Azure.CosmosRepositoryTests
@@ -34,9 +36,38 @@ namespace Microsoft.Azure.CosmosRepositoryTests
 
             Assert.NotNull(factory.RepositoryOf<AnotherTestItem>());
             Assert.NotNull(factory.RepositoryOf<AndAnotherItem>());
+            Assert.NotNull(factory.RepositoryOf<AndACustomEntity>());
         }
     }
 
     public class AnotherTestItem : Item { }
     public class AndAnotherItem : Item { }
+    public class AndACustomEntity : CustomEntityBase { }
+
+    /// <summary>
+    /// Sample custom base object that implements IItem
+    /// </summary>
+    public abstract class CustomEntityBase : IItem
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("quest")]
+        public string Quest { get; set; }
+
+        [JsonProperty("favoritecolor")]
+        public string FavoriteColor { get; set; }
+
+        PartitionKey IItem.PartitionKey => new PartitionKey(GetPartitionKeyValue());
+
+        public CustomEntityBase() => Type = GetType().Name;
+
+        protected virtual string GetPartitionKeyValue() => Id;
+    }
 }

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
 
             string path = provider.GetPartitionKeyPath<PickleChipsItem>();
             Assert.Equal("/pickles", path);
-            Assert.Equal("[\"Hey, where's the chips?!\"]", new PickleChipsItem().PartitionKey.ToString());
+            Assert.Equal("[\"Hey, where's the chips?!\"]", ((IItem)new PickleChipsItem()).PartitionKey.ToString());
         }
     }
 


### PR DESCRIPTION
Per [this discussion](https://github.com/IEvangelist/azure-cosmos-dotnet-repository/issues/35), this PR creates an `IItem` abstraction over the Item class, to allow for a custom implementation of the concrete base class when desired. A typical use case is in a brownfield scenario with an existing base entity class, and/or scenarios where base adaptors for multiple databases need to coexist in the same entity. An example usage is shown in _DefaultRepositoryFactoryTests.cs_ [here](https://github.com/IEvangelist/azure-cosmos-dotnet-repository/compare/main...dcuccia:main#diff-ecc142928f54ba144c938a65907992fb12fc8b7d7560fe2d147377728d7fb462). This is primarily to show the usage of the interface - clearly, we might do more to test this, beyond the 1-liner addition to `RepositoryFactoryCorrectlyGetsRepositoryTest()`. Open to suggestions! Thanks for considering!

Closes #35