### PR TITLE
Returns null instead of 404 exception.

### DIFF
--- a/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
+++ b/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.CosmosRepository
                 partitionKey = new PartitionKey(id);
             }
 
-            ItemResponse<TItem> response;
+            ItemResponse<TItem> response = null;
 
             try
             {
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.CosmosRepository
             }
             catch (CosmosException e) when (e.StatusCode == HttpStatusCode.NotFound)
             {
-                throw;
+
             }
 
             if (response is null)


### PR DESCRIPTION
Have been using the library today and found when doing a point read an the item does not exist rather than getting null back from the repository it throws an exception. Changed it to now return null when a ComosException is thrown with the 404 status code.