### PR TITLE
Relax IItem PartitionKey type to string to remove Cosmos dependency

### DIFF
--- a/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
+++ b/Microsoft.Azure.CosmosRepository/src/DefaultRepository.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.CosmosRepository
                 await _containerProvider.GetContainerAsync().ConfigureAwait(false);
 
             ItemResponse<TItem> response =
-                await container.CreateItemAsync(value, value.PartitionKey, cancellationToken: cancellationToken)
+                await container.CreateItemAsync(value, new PartitionKey(value.PartitionKey), cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
 
             TryLogDebugDetails(_logger, () => $"Created: {JsonConvert.SerializeObject(value)}");
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.CosmosRepository
             Container container = await _containerProvider.GetContainerAsync().ConfigureAwait(false);
 
             ItemResponse<TItem> response =
-                await container.UpsertItemAsync<TItem>(value, value.PartitionKey, options, cancellationToken)
+                await container.UpsertItemAsync<TItem>(value, new PartitionKey(value.PartitionKey), options, cancellationToken)
                     .ConfigureAwait(false);
 
             TryLogDebugDetails(_logger, () => $"Updated: {JsonConvert.SerializeObject(value)}");

--- a/Microsoft.Azure.CosmosRepository/src/IItem.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Azure.Cosmos;
-
 namespace Microsoft.Azure.CosmosRepository
 {
     /// <summary>

--- a/Microsoft.Azure.CosmosRepository/src/IItem.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IItem.cs
@@ -23,6 +23,6 @@ namespace Microsoft.Azure.CosmosRepository
         /// <summary>
         /// Gets the item's PartitionKey.
         /// </summary>
-        PartitionKey PartitionKey { get; }
+        string PartitionKey { get; }
     }
 }

--- a/Microsoft.Azure.CosmosRepository/src/IItem.cs
+++ b/Microsoft.Azure.CosmosRepository/src/IItem.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.CosmosRepository
         string Type { get; set; }
 
         /// <summary>
-        /// Gets the item's PartitionKey.
+        /// Gets the item's PartitionKey. This string is used to instantiate the <c>Cosmos.PartitionKey</c> struct.
         /// </summary>
         string PartitionKey { get; }
     }

--- a/Microsoft.Azure.CosmosRepository/src/Item.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Item.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// Gets the PartitionKey based on <see cref="GetPartitionKeyValue"/>.
         /// Implemented explicitly to keep out of Item API
         /// </summary>
-        PartitionKey IItem.PartitionKey => new(GetPartitionKeyValue());
+        string IItem.PartitionKey => GetPartitionKeyValue();
 
         /// <summary>
         /// Default constructor, assigns type name to <see cref="Type"/> property.

--- a/Microsoft.Azure.CosmosRepository/test/DefaultRepositoryFactoryTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/DefaultRepositoryFactoryTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests
         [JsonProperty("favoritecolor")]
         public string FavoriteColor { get; set; }
 
-        PartitionKey IItem.PartitionKey => new PartitionKey(GetPartitionKeyValue());
+        string IItem.PartitionKey => GetPartitionKeyValue();
 
         public CustomEntityBase() => Type = GetType().Name;
 

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
 
             string path = provider.GetPartitionKeyPath<PickleChipsItem>();
             Assert.Equal("/pickles", path);
-            Assert.Equal("[\"Hey, where's the chips?!\"]", ((IItem)new PickleChipsItem()).PartitionKey.ToString());
+            Assert.Equal("[\"Hey, where's the chips?!\"]", new Cosmos.PartitionKey(((IItem)new PickleChipsItem()).PartitionKey).ToString());
         }
     }
 


### PR DESCRIPTION
@IEvangelist I got around to using the `IItem` interface we created in [PR 36](https://github.com/IEvangelist/azure-cosmos-dotnet-repository/pull/36), and realized there was still a hard dependency on the `PartitionKey` type. This was quite inconvenient, because I had to pull in Cosmos at my contracts/DTO layer. This PR would change that type to a string, and push the `PartitionKey` ctor call to the repository level, at the time of calling `CreateItemAsync`/`UpsertItemAsync`. There was not caching of this value anyway, so I don't think there would be a performance difference in any case. Does this look ok? Anything different/else you'd want to do here?

Thanks!
David