### PR TITLE
Auto deploy to nuget on a tag

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -41,7 +41,7 @@ jobs:
       
     - name: Pack
       run: |
-        dotnet pack ./Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj -p:PackageVersion='${{ steps.regex-match.outputs.match }}' --output packages
+        dotnet pack ./Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj --output packages
       
     - name: Publish Package
       run: |

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,0 +1,55 @@
+name: Release Package Version
+on:
+  push:
+    tags:
+     - v*     
+jobs: 
+  build:
+    if: github.event.base_ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:    
+    
+    - name: Print Tag Ref
+      run: echo $GITHUB_REF
+      
+    - name: Extract Version Number
+      uses: actions-ecosystem/action-regex-match@v2
+      id: regex-match
+      with:
+        text: ${{ github.ref }}
+        regex: '[0-9.]+'
+       
+    - name: Print Version Number
+      run: echo '${{ steps.regex-match.outputs.match }}'
+      
+    - uses: actions/checkout@v2
+    - name: Setup .NET  
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: |
+        dotnet build --configuration Release --no-restore
+      
+    - name: Test
+      run: |
+        dotnet test --no-restore --verbosity normal
+      
+    - name: Pack
+      run: |
+        dotnet pack ./Microsoft.Azure.CosmosRepository/src/Microsoft.Azure.CosmosRepository.csproj -p:PackageVersion='${{ steps.regex-match.outputs.match }}' --output packages
+      
+    - name: Publish Package
+      run: |
+        nuget push **\*.nupkg -NoSymbols -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}}
+      
+    - name: Upload Package
+      uses: actions/upload-artifact@v2
+      with:
+        name: IEvangelist.Azure.CosmosRepository.V${{ steps.regex-match.outputs.match }}
+        path: packages/
+        


### PR DESCRIPTION
This will start the build when a tag is added to master branch such as `v1.1` this then extracts the version number from it and versions the package with this version which is then published to nuget.org.