### PR TITLE
Specify RU/s at the container level

### DIFF
--- a/Microsoft.Azure.CosmosRepository.Samples/AzureFunctionTier/Startup.cs
+++ b/Microsoft.Azure.CosmosRepository.Samples/AzureFunctionTier/Startup.cs
@@ -17,6 +17,7 @@ namespace AzureFunctionTier
                     .WithContainer("users")
                     .WithPartitionKey("/emailAddress")
                     .WithContainerDefaultTimeToLive(TimeSpan.FromMinutes(1))
+                    .WithManualThroughput(500)
                     .WithSyncableContainerProperties()
                 );
             });

--- a/Microsoft.Azure.CosmosRepository/src/Builders/ContainerOptionsBuilder.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Builders/ContainerOptionsBuilder.cs
@@ -123,7 +123,9 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         {
             if (maxAutoScaleThroughput is < 4_000 or > 1_000_000)
             {
-                throw new ArgumentOutOfRangeException(nameof(maxAutoScaleThroughput),"Autoscale throughput must be between 4,000 and 1,000,000 RUs.");
+                throw new ArgumentOutOfRangeException(
+                    nameof(maxAutoScaleThroughput),
+                    "Autoscale throughput must be between 4,000 and 1,000,000 RUs.");
             }
 
             if (maxAutoScaleThroughput % 1000 != 0)

--- a/Microsoft.Azure.CosmosRepository/src/Builders/ContainerOptionsBuilder.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Builders/ContainerOptionsBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.Azure.Cosmos;
 
 namespace Microsoft.Azure.CosmosRepository.Builders
 {
@@ -44,6 +45,12 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         internal bool SyncContainerProperties { get; private set; }
 
         /// <summary>
+        /// The <see cref="ThroughputProperties"/> for the given container.
+        /// </summary>
+        /// <remarks>By default this uses a manual throughput reserved at 400 RU/s in line with the Cosmos SDK.</remarks>
+        internal ThroughputProperties ThroughputProperties { get; private set; } = ThroughputProperties.CreateManualThroughput(400);
+
+        /// <summary>
         /// Sets the <see cref="ContainerDefaultTimeToLive"/> for a container.
         /// </summary>
         /// <param name="containerDefaultTimeToLive">The default time to live for the container.</param>
@@ -84,6 +91,47 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         public ContainerOptionsBuilder WithSyncableContainerProperties()
         {
             SyncContainerProperties = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the container for this <see cref="IItem"/> to use a manual throughput value.
+        /// </summary>
+        /// <param name="throughput">The RU/s that this container can utilise.</param>
+        /// <remarks>This value must be at least 400 RU/s.</remarks>
+        /// <remarks>If a container has already been created without specifying a throughput then it cannot be updated.</remarks>
+        /// <exception cref="InvalidOperationException">When the RU/s is less than 400.</exception>
+        /// <returns>Instance of <see cref="ContainerOptionsBuilder"/></returns>
+        public ContainerOptionsBuilder WithManualThroughput(int throughput = 400)
+        {
+            if (throughput < 400)
+            {
+                throw new ArgumentOutOfRangeException(nameof(throughput),"A container must at least set a throughput level of 400 RU/s");
+            }
+
+            ThroughputProperties = ThroughputProperties.CreateManualThroughput(throughput);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the container for this <see cref="IItem"/> to use a autoscale throughput value.
+        /// </summary>
+        /// <param name="maxAutoScaleThroughput">The maximum RU/s that this containers throughput can autoscale to.</param>
+        /// <remarks>If a container has already been created without specifying a throughput then it cannot be updated.</remarks>
+        /// <returns>Instance of <see cref="ContainerOptionsBuilder"/></returns>
+        public ContainerOptionsBuilder WithAutoscaleThroughput(int maxAutoScaleThroughput = 4_000)
+        {
+            if (maxAutoScaleThroughput is < 4_000 or > 1_000_000)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxAutoScaleThroughput),"Autoscale throughput must be between 4,000 and 1,000,000 RUs.");
+            }
+
+            if (maxAutoScaleThroughput % 1000 != 0)
+            {
+                throw new InvalidOperationException("Autoscale throughput must be defined in increments of 1,000");
+            }
+
+            ThroughputProperties = ThroughputProperties.CreateAutoscaleThroughput(maxAutoScaleThroughput);
             return this;
         }
     }

--- a/Microsoft.Azure.CosmosRepository/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Extensions/ServiceCollectionExtensions.cs
@@ -65,7 +65,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     .AddSingleton<ICosmosContainerDefaultTimeToLiveProvider, DefaultCosmosContainerDefaultTimeToLiveProvider>()
                     .AddSingleton<ICosmosContainerSyncContainerPropertiesProvider, DefaultContainerSyncContainerPropertiesProvider>()
                     .AddSingleton<ICosmosContainerService, DefaultCosmosContainerService>()
-                    .AddSingleton<ICosmosContainerSyncService, DefaultCosmosContainerSyncService>();
+                    .AddSingleton<ICosmosContainerSyncService, DefaultCosmosContainerSyncService>()
+                    .AddSingleton<ICosmosThroughputProvider, DefaultCosmosThroughputProvider>();
 
             if (setupAction != default)
             {

--- a/Microsoft.Azure.CosmosRepository/src/Options/ItemOptions.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Options/ItemOptions.cs
@@ -16,15 +16,19 @@ namespace Microsoft.Azure.CosmosRepository.Options
 
         public UniqueKeyPolicy UniqueKeyPolicy { get; }
 
+        public ThroughputProperties ThroughputProperties { get; }
+
         public int DefaultTimeToLive { get; }
+
         public bool SyncContainerProperties { get; }
 
-        public ItemOptions(Type type, string containerName, string partitionKeyPath, UniqueKeyPolicy uniqueKeyPolicy, int defaultTimeToLive = -1, bool syncContainerProperties = false)
+        public ItemOptions(Type type, string containerName, string partitionKeyPath, UniqueKeyPolicy uniqueKeyPolicy,ThroughputProperties throughputProperties, int defaultTimeToLive = -1, bool syncContainerProperties = false)
         {
             Type = type;
             ContainerName = containerName;
             PartitionKeyPath = partitionKeyPath;
             UniqueKeyPolicy = uniqueKeyPolicy;
+            ThroughputProperties = throughputProperties;
             DefaultTimeToLive = defaultTimeToLive;
             SyncContainerProperties = syncContainerProperties;
         }

--- a/Microsoft.Azure.CosmosRepository/src/Options/RepositoryOptions.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Options/RepositoryOptions.cs
@@ -98,5 +98,16 @@ namespace Microsoft.Azure.CosmosRepository.Options
         /// <returns>null or <see cref="ContainerOptionsBuilder"/>.</returns>
         internal ContainerOptionsBuilder GetContainerOptions<TItem>() where TItem : IItem =>
             ContainerOptions.FirstOrDefault(co => co.Type == typeof(TItem));
+
+        /// <summary>
+        /// Gets container options for <see cref="IItem"/>s that share the same container.
+        /// </summary>
+        /// <typeparam name="TItem">The type of <see cref="IItem"/> to find common types for.</typeparam>
+        /// <returns>A collection of <see cref="ContainerOptionsBuilder"/>s that share the same container.</returns>
+        internal IEnumerable<ContainerOptionsBuilder> GetContainerSharedContainerOptions<TItem>() where TItem : IItem
+        {
+            ContainerOptionsBuilder containerOptionsBuilder = GetContainerOptions<TItem>();
+            return containerOptionsBuilder is not null ? ContainerOptions.Where(co => co.Name == containerOptionsBuilder.Name) : new List<ContainerOptionsBuilder>();
+        }
     }
 }

--- a/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosContainerDefaultTimeToLiveProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosContainerDefaultTimeToLiveProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers
                 return -1;
             }
 
-            foreach (ContainerOptionsBuilder containerOptions in _options.Value.ContainerOptions.Where(co => co.Name == options.Name))
+            foreach (ContainerOptionsBuilder containerOptions in _options.Value.GetContainerSharedContainerOptions<TItem>())
             {
                 if (containerOptions.ContainerDefaultTimeToLive != null && containerOptions.ContainerDefaultTimeToLive != options.ContainerDefaultTimeToLive)
                 {

--- a/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosItemConfigurationProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosItemConfigurationProvider.cs
@@ -17,19 +17,22 @@ namespace Microsoft.Azure.CosmosRepository.Providers
         private readonly ICosmosUniqueKeyPolicyProvider _cosmosUniqueKeyPolicyProvider;
         private readonly ICosmosContainerDefaultTimeToLiveProvider _containerDefaultTimeToLiveProvider;
         private readonly ICosmosContainerSyncContainerPropertiesProvider _syncContainerPropertiesProvider;
+        readonly ICosmosThroughputProvider _cosmosThroughputProvider;
 
         public DefaultCosmosItemConfigurationProvider(
             ICosmosContainerNameProvider containerNameProvider,
             ICosmosPartitionKeyPathProvider cosmosPartitionKeyPathProvider,
             ICosmosUniqueKeyPolicyProvider cosmosUniqueKeyPolicyProvider,
             ICosmosContainerDefaultTimeToLiveProvider containerDefaultTimeToLiveProvider,
-            ICosmosContainerSyncContainerPropertiesProvider syncContainerPropertiesProvider)
+            ICosmosContainerSyncContainerPropertiesProvider syncContainerPropertiesProvider,
+            ICosmosThroughputProvider cosmosThroughputProvider)
         {
             _containerNameProvider = containerNameProvider;
             _cosmosPartitionKeyPathProvider = cosmosPartitionKeyPathProvider;
             _cosmosUniqueKeyPolicyProvider = cosmosUniqueKeyPolicyProvider;
             _containerDefaultTimeToLiveProvider = containerDefaultTimeToLiveProvider;
             _syncContainerPropertiesProvider = syncContainerPropertiesProvider;
+            _cosmosThroughputProvider = cosmosThroughputProvider;
         }
 
         public ItemOptions GetOptions<TItem>() where TItem : IItem =>
@@ -42,8 +45,9 @@ namespace Microsoft.Azure.CosmosRepository.Providers
             UniqueKeyPolicy uniqueKeyPolicy = _cosmosUniqueKeyPolicyProvider.GetUniqueKeyPolicy<TItem>();
             int timeToLive = _containerDefaultTimeToLiveProvider.GetDefaultTimeToLive<TItem>();
             bool sync = _syncContainerPropertiesProvider.GetWhetherToSyncContainerProperties<TItem>();
+            ThroughputProperties throughputProperties = _cosmosThroughputProvider.GetThroughputProperties<TItem>();
 
-            return new(optionType, containerName, partitionKeyPath, uniqueKeyPolicy, timeToLive, sync);
+            return new(optionType, containerName, partitionKeyPath, uniqueKeyPolicy, throughputProperties, timeToLive, sync);
         }
     }
 }

--- a/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosThroughputProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/DefaultCosmosThroughputProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.CosmosRepository.Builders;
+using Microsoft.Azure.CosmosRepository.Options;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.CosmosRepository.Providers
+{
+    /// <inheritdoc/>
+    class DefaultCosmosThroughputProvider : ICosmosThroughputProvider
+    {
+        readonly IOptions<RepositoryOptions> _options;
+
+        public DefaultCosmosThroughputProvider(IOptions<RepositoryOptions> options) =>
+            _options = options;
+
+        /// <inheritdoc/>
+        public ThroughputProperties GetThroughputProperties<TItem>() where TItem : IItem
+        {
+            ContainerOptionsBuilder currentItemsOptions = _options.Value.GetContainerOptions<TItem>();
+
+            if (currentItemsOptions is null)
+            {
+                return ThroughputProperties.CreateManualThroughput(400);
+            }
+
+            foreach (ContainerOptionsBuilder option in _options.Value.GetContainerSharedContainerOptions<TItem>())
+            {
+                if (currentItemsOptions.ThroughputProperties.Throughput != null &&
+                    option.ThroughputProperties.Throughput != currentItemsOptions.ThroughputProperties.Throughput)
+                {
+                    throw new InvalidOperationException($"The container {option.Name} has conflicting manual throughput properties. " +
+                                                        $"({option.Type.Name}->{option.ThroughputProperties.Throughput} vs " +
+                                                        $"{currentItemsOptions.Type.Name}->{currentItemsOptions.ThroughputProperties.Throughput}).");
+                }
+
+                if (option.ThroughputProperties.AutoscaleMaxThroughput != null &&
+                    option.ThroughputProperties.AutoscaleMaxThroughput != currentItemsOptions.ThroughputProperties.AutoscaleMaxThroughput)
+                {
+                    throw new InvalidOperationException($"The container {option.Name} has conflicting autoscale throughput properties. " +
+                                                        $"({option.Type.Name}->{option.ThroughputProperties.AutoscaleMaxThroughput} vs " +
+                                                        $"{currentItemsOptions.Type.Name}->{currentItemsOptions.ThroughputProperties.AutoscaleMaxThroughput}).");
+                }
+            }
+
+            return currentItemsOptions.ThroughputProperties;
+        }
+    }
+}

--- a/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosThroughputProvider.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Providers/ICosmosThroughputProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.CosmosRepository.Providers
+{
+    /// <summary>
+    /// Exposes the ability to get an <see cref="IItem"/>s containers throughput properties.
+    /// </summary>
+    public interface ICosmosThroughputProvider
+    {
+        /// <summary>
+        /// Gets the throughput properties for the given <see cref="IItem"/>s container.
+        /// </summary>
+        /// <typeparam name="TItem">The type of <see cref="IItem"/></typeparam>
+        /// <returns><see cref="ThroughputProperties"/> for the <see cref="IItem"/>s container.</returns>
+        ThroughputProperties GetThroughputProperties<TItem>() where TItem : IItem;
+    }
+}

--- a/Microsoft.Azure.CosmosRepository/src/Services/DefaultCosmosContainerService.cs
+++ b/Microsoft.Azure.CosmosRepository/src/Services/DefaultCosmosContainerService.cs
@@ -53,10 +53,11 @@ namespace Microsoft.Azure.CosmosRepository.Services
 
                 Container container =
                     await database.CreateContainerIfNotExistsAsync(
-                        containerProperties).ConfigureAwait(false);
+                        containerProperties, itemOptions.ThroughputProperties).ConfigureAwait(false);
 
                 if (itemOptions.SyncContainerProperties || forceContainerSync)
                 {
+                    await container.ReplaceThroughputAsync(itemOptions.ThroughputProperties);
                     await container.ReplaceContainerAsync(containerProperties);
                 }
 

--- a/Microsoft.Azure.CosmosRepository/test/Options/RepositoryOptionsTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Options/RepositoryOptionsTests.cs
@@ -31,12 +31,31 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Options
             => Assert.Throws<ArgumentNullException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(options => options.WithContainer(null)));
 
         [Fact]
-        public void RepositoryOptionsBuilderThrowsArgumentNullExceptionWhenPartionKeyIsNull()
+        public void RepositoryOptionsBuilderThrowsArgumentNullExceptionWhenPartitionKeyIsNull()
             => Assert.Throws<ArgumentNullException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(options => options.WithPartitionKey(null)));
 
         [Fact]
         public void RepositoryOptionsBuilderThrowsArgumentNullExceptionWhenContainerBuilderActionIsNull()
             => Assert.Throws<ArgumentNullException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(null));
+
+        [Theory]
+        [InlineData(300)]
+        [InlineData(1_100_000)]
+        public void RepositoryOptionsBuilderThrowsOutOfRangeExceptionWhenAutoscaleThroughputIsOutOfRange(int throughput) =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(builder => builder.WithAutoscaleThroughput(throughput)));
+
+        [Theory]
+        [InlineData(1500)]
+        [InlineData(1_150_000)]
+        public void RepositoryOptionsBuilderThrowsInvalidOperationExceptionWhenAutoscaleThroughputNotAMultipleOf1000(int throughput) =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(builder => builder.WithAutoscaleThroughput(throughput)));
+
+
+        [Theory]
+        [InlineData(200)]
+        [InlineData(100)]
+        public void RepositoryOptionsBuilderThrowsOutOfRangeExceptionWhenManualThroughputIsOutOfRange(int throughput) =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => new RepositoryOptions().ContainerBuilder.Configure<Product>(builder => builder.WithManualThroughput(throughput)));
     }
 
     public class Product : Item

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosItemConfigurationProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosItemConfigurationProviderTests.cs
@@ -12,11 +12,12 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
 {
     public class DefaultCosmosItemConfigurationProviderTests
     {
-        private readonly Mock<ICosmosContainerNameProvider> _containerNameProvider = new();
-        private readonly Mock<ICosmosPartitionKeyPathProvider> _partitionKeyPathProvider = new();
-        private readonly Mock<ICosmosUniqueKeyPolicyProvider> _uniqueKeyPolicyProvider = new();
-        private readonly Mock<ICosmosContainerDefaultTimeToLiveProvider> _defaultTimeToLiveProvider = new();
-        private readonly Mock<ICosmosContainerSyncContainerPropertiesProvider> _syncContainerPropertiesProvider = new();
+        readonly Mock<ICosmosContainerNameProvider> _containerNameProvider = new();
+        readonly Mock<ICosmosPartitionKeyPathProvider> _partitionKeyPathProvider = new();
+        readonly Mock<ICosmosUniqueKeyPolicyProvider> _uniqueKeyPolicyProvider = new();
+        readonly Mock<ICosmosContainerDefaultTimeToLiveProvider> _defaultTimeToLiveProvider = new();
+        readonly Mock<ICosmosContainerSyncContainerPropertiesProvider> _syncContainerPropertiesProvider = new();
+        readonly Mock<ICosmosThroughputProvider> _throughputProvider = new();
 
         [Fact]
         public void GetOptionsAlwaysGetOptionsForItem()
@@ -26,15 +27,18 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
                 _partitionKeyPathProvider.Object,
                 _uniqueKeyPolicyProvider.Object,
                 _defaultTimeToLiveProvider.Object,
-                _syncContainerPropertiesProvider.Object);
+                _syncContainerPropertiesProvider.Object,
+                _throughputProvider.Object);
 
             UniqueKeyPolicy uniqueKeyPolicy = new();
+            ThroughputProperties throughputProperties = ThroughputProperties.CreateAutoscaleThroughput(400);
 
             _containerNameProvider.Setup(o => o.GetContainerName<Item1>()).Returns("a");
             _partitionKeyPathProvider.Setup(o => o.GetPartitionKeyPath<Item1>()).Returns("/id");
             _uniqueKeyPolicyProvider.Setup(o => o.GetUniqueKeyPolicy<Item1>()).Returns(uniqueKeyPolicy);
             _defaultTimeToLiveProvider.Setup(o => o.GetDefaultTimeToLive<Item1>()).Returns(10);
             _syncContainerPropertiesProvider.Setup(o => o.GetWhetherToSyncContainerProperties<Item1>()).Returns(true);
+            _throughputProvider.Setup(o => o.GetThroughputProperties<Item1>()).Returns(throughputProperties);
 
             ItemOptions options = provider.GetOptions<Item1>();
 
@@ -43,6 +47,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
             Assert.Equal(uniqueKeyPolicy, options.UniqueKeyPolicy);
             Assert.Equal(10, options.DefaultTimeToLive);
             Assert.True(options.SyncContainerProperties);
+            Assert.Equal(throughputProperties, options.ThroughputProperties);
         }
 
         class Item1 : Item

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
 {
     public class DefaultCosmosThroughputProviderTests : WithRepositoryOptions
     {
-
         readonly DefaultCosmosThroughputProvider _provider;
 
         public DefaultCosmosThroughputProviderTests() =>

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
@@ -73,6 +73,5 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Providers
             Assert.Contains("500", exception.Message);
             Assert.Contains("700", exception.Message);
         }
-
     }
 }

--- a/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
+++ b/Microsoft.Azure.CosmosRepository/test/Providers/DefaultCosmosThroughputProviderTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.CosmosRepository.Providers;
+using Microsoft.Azure.CosmosRepositoryTests.Abstractions;
+using Microsoft.Azure.CosmosRepositoryTests.Stubs;
+using Xunit;
+
+namespace Microsoft.Azure.CosmosRepositoryTests.Providers
+{
+    public class DefaultCosmosThroughputProviderTests : WithRepositoryOptions
+    {
+
+        readonly DefaultCosmosThroughputProvider _provider;
+
+        public DefaultCosmosThroughputProviderTests() =>
+            _provider = new DefaultCosmosThroughputProvider(_options.Object);
+
+        [Fact]
+        public void GetThroughputPropertiesGivenItemWithNoSettingsReturnManualThroughputPropertiesSetTo400RUs()
+        {
+            ThroughputProperties throughputProperties = _provider.GetThroughputProperties<TestItem>();
+
+            Assert.Equal(400, throughputProperties.Throughput);
+            Assert.Null(throughputProperties.AutoscaleMaxThroughput);
+        }
+
+        [Fact]
+        public void GetThroughputPropertiesItemAutoscaleThroughputProperties()
+        {
+            _repositoryOptions.ContainerBuilder.Configure<TestItem>(builder => builder.WithAutoscaleThroughput());
+            ThroughputProperties throughputProperties = _provider.GetThroughputProperties<TestItem>();
+
+            Assert.Equal(4000, throughputProperties.AutoscaleMaxThroughput);
+            Assert.Null(throughputProperties.Throughput);
+        }
+
+        [Fact]
+        public void GetThroughputPropertiesItemManualThroughputProperties()
+        {
+            _repositoryOptions.ContainerBuilder.Configure<TestItem>(builder => builder.WithManualThroughput(500));
+            ThroughputProperties throughputProperties = _provider.GetThroughputProperties<TestItem>();
+
+            Assert.Equal(500, throughputProperties.Throughput);
+            Assert.Null(throughputProperties.AutoscaleMaxThroughput);
+        }
+
+        [Fact]
+        public void GetThroughputPropertiesItemsWithConflictingAutoscaleValues()
+        {
+            _repositoryOptions.ContainerBuilder
+                .Configure<TestItem>(builder => builder.WithAutoscaleThroughput(4000))
+                .Configure<AnotherTestItem>(builder => builder.WithAutoscaleThroughput(5000));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => _provider.GetThroughputProperties<TestItem>());
+
+            Assert.Contains("autoscale", exception.Message);
+            Assert.Contains("4000", exception.Message);
+            Assert.Contains("5000", exception.Message);
+        }
+
+        [Fact]
+        public void GetThroughputPropertiesItemsWithConflictingManualValues()
+        {
+            _repositoryOptions.ContainerBuilder
+                .Configure<TestItem>(builder => builder.WithManualThroughput(500))
+                .Configure<AnotherTestItem>(builder => builder.WithManualThroughput(700));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => _provider.GetThroughputProperties<TestItem>());
+
+            Assert.Contains("manual", exception.Message);
+            Assert.Contains("500", exception.Message);
+            Assert.Contains("700", exception.Message);
+        }
+
+    }
+}


### PR DESCRIPTION
Closes #107.

There are, however, a few nuances around this that are going to need to be documented see below:

1. A container cannot switch between manual & autoscale throughput.
2. If a container has already been created with no throughput properties then these cannot be applied.

See some documentation here: https://docs.microsoft.com/en-us/azure/cosmos-db/set-throughput#update-throughput-on-a-database-or-a-container