### PR TITLE
Test CI Improvements

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -12,8 +12,36 @@ on:
         description: 'The reason for running the workflow'
         required: true
         default: 'Manual run'
+       
+# Only one instance of this build at a time. 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  pre-test:
+    name: pre-test
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            3.1.402
+            6.0.x
+  
+      - name: Install dependencies
+        working-directory: ./tools/CosmosTestHelper
+        run: dotnet restore
+        
+      - name: Prune databases
+        working-directory: ./tools/CosmosTestHelper
+        env:
+          CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+        run: dotnet run
+
   build:
     name: build-${{matrix.os}}
     runs-on: ${{ matrix.os }}
@@ -40,5 +68,6 @@ jobs:
     - name: Test
       env:
         CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+        OperatingSystemKey: ${{ martix.os }}
       run: |
         dotnet test --no-restore --verbosity normal

--- a/Microsoft.Azure.CosmosRepository.sln
+++ b/Microsoft.Azure.CosmosRepository.sln
@@ -53,6 +53,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.CosmosRepos
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.CosmosRepositoryAcceptanceTests", "tests\Microsoft.Azure.CosmosRepositoryAcceptanceTests\Microsoft.Azure.CosmosRepositoryAcceptanceTests.csproj", "{C8E5121C-7AE6-4819-9D86-F0D5418D5EC3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{8704E3AA-99EC-4D9A-AB6B-4AC72D0207E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosTestHelper", "tools\CosmosTestHelper\CosmosTestHelper.csproj", "{86B938CF-7671-4B66-B831-C9EB6D73FD85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -113,6 +117,10 @@ Global
 		{CDF603BA-5474-45E9-BBA1-2D33CAD12062}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8E5121C-7AE6-4819-9D86-F0D5418D5EC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8E5121C-7AE6-4819-9D86-F0D5418D5EC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86B938CF-7671-4B66-B831-C9EB6D73FD85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86B938CF-7671-4B66-B831-C9EB6D73FD85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86B938CF-7671-4B66-B831-C9EB6D73FD85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86B938CF-7671-4B66-B831-C9EB6D73FD85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -129,6 +137,7 @@ Global
 		{C09F2BE0-1E3C-445A-886E-FBF806D0C9BB} = {9BC98AA9-78A9-4AAA-998C-461CC09DFFDE}
 		{9BB9074A-9478-41A3-A108-5E5775DB8353} = {9BC98AA9-78A9-4AAA-998C-461CC09DFFDE}
 		{C9ED77BA-3E5A-4977-B3C2-BD0D91A5C432} = {9BC98AA9-78A9-4AAA-998C-461CC09DFFDE}
+		{86B938CF-7671-4B66-B831-C9EB6D73FD85} = {8704E3AA-99EC-4D9A-AB6B-4AC72D0207E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AAE7641-B62C-48BA-8FE6-0F819E5B45EF}

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/CosmosRepositoryAcceptanceTest.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/CosmosRepositoryAcceptanceTest.cs
@@ -83,9 +83,12 @@ public abstract class CosmosRepositoryAcceptanceTest
 
     protected static readonly Action<RepositoryOptions> DefaultTestRepositoryOptions = options =>
     {
+        string os = Environment.GetEnvironmentVariable("OperatingSystemKey") ??
+                    Environment.OSVersion.Platform.ToString().ToLower();
+
         options.CosmosConnectionString = Environment.GetEnvironmentVariable("CosmosConnectionString");
         options.ContainerPerItemType = true;
-        options.DatabaseId = "cosmos-repository-acceptance-tests";
+        options.DatabaseId = $"cosmos-repository-acceptance-tests-{os}";
 
         ConfigureProducts(options);
         ConfigureRatings(options);

--- a/tools/CosmosTestHelper/CosmosTestHelper.csproj
+++ b/tools/CosmosTestHelper/CosmosTestHelper.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
+    </ItemGroup>
+
+</Project>

--- a/tools/CosmosTestHelper/Program.cs
+++ b/tools/CosmosTestHelper/Program.cs
@@ -2,7 +2,6 @@
 
 Console.WriteLine("Starting to query all databases from cosmos account");
 
-
 CosmosClient client = new(
     Environment.GetEnvironmentVariable("CosmosConnectionString"));
 

--- a/tools/CosmosTestHelper/Program.cs
+++ b/tools/CosmosTestHelper/Program.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Azure.Cosmos;
+
+Console.WriteLine("Starting to query all databases from cosmos account");
+
+
+CosmosClient client = new(
+    Environment.GetEnvironmentVariable("CosmosConnectionString"));
+
+using FeedIterator<DatabaseProperties> databases =
+    client.GetDatabaseQueryIterator<DatabaseProperties>("SELECT * FROM c");
+
+int total = 0;
+
+while (databases.HasMoreResults)
+{
+    FeedResponse<DatabaseProperties> response = await databases.ReadNextAsync();
+    foreach (DatabaseProperties databaseProperties in response)
+    {
+        Console.WriteLine($"Deleting database {databaseProperties.Id}");
+
+        Database database = client.GetDatabase(databaseProperties.Id);
+
+        await database.DeleteAsync();
+
+        Console.WriteLine($"Deleted database {database.Id}");
+        total++;
+    }
+}
+
+Console.WriteLine($"Deleted a total of ({total} databases");


### PR DESCRIPTION
* The tests now run on a database that includes their OS name to avoid clashes.
* Turned on batch builds, only run one master CI build at a time, newest wins.
* Added a small console app to clear down the databases at the beginning of a test run.