### PR TITLE
Updated etag in memory repository behaviour 

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/EtagItem.cs
+++ b/src/Microsoft.Azure.CosmosRepository/EtagItem.cs
@@ -30,8 +30,25 @@ namespace Microsoft.Azure.CosmosRepository
     /// ]]>
     /// </code>
     /// </example>
-    public class EtagItem : Item, IItemWithEtag
+    public abstract class EtagItem : Item, IItemWithEtag
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        protected EtagItem()
+        {
+
+        }
+
+        /// <summary>
+        /// A constructor that allows the etag to be set so that items can be mapped to and from other objects
+        /// </summary>
+        /// <param name="etag"></param>
+        protected EtagItem(string etag)
+        {
+            Etag = etag;
+        }
+
         /// <summary>
         /// Etag for the item which was set by Cosmos the last time the item was updated. This string is used for the relevant operations when specified.
         /// </summary>

--- a/src/Microsoft.Azure.CosmosRepository/EtagItem.cs
+++ b/src/Microsoft.Azure.CosmosRepository/EtagItem.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         protected EtagItem()
         {
-
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.CosmosRepository/FullItem.cs
+++ b/src/Microsoft.Azure.CosmosRepository/FullItem.cs
@@ -34,6 +34,24 @@ namespace Microsoft.Azure.CosmosRepository
     /// </example>
     public abstract class FullItem : Item, IItemWithEtag, IItemWithTimeToLive, IItemWithTimeStamps
     {
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        protected FullItem()
+        {
+
+        }
+
+        /// <summary>
+        /// A constructor that allows the etag to be set so that items can be mapped to and from other objects
+        /// </summary>
+        /// <param name="etag"></param>
+        protected FullItem(string etag)
+        {
+            Etag = etag;
+        }
+
         /// <inheritdoc />
         [JsonProperty("_etag")]
         public string? Etag { get; private set; }

--- a/src/Microsoft.Azure.CosmosRepository/FullItem.cs
+++ b/src/Microsoft.Azure.CosmosRepository/FullItem.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         protected FullItem()
         {
-
         }
 
         /// <summary>

--- a/src/Microsoft.Azure.CosmosRepository/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/InMemoryRepository.cs
@@ -179,6 +179,7 @@ namespace Microsoft.Azure.CosmosRepository
             await Task.CompletedTask;
 
             if (value is IItemWithEtag valueWithEtag &&
+                !string.IsNullOrWhiteSpace(valueWithEtag.Etag) &&
                 Items.ContainsKey(value.Id) &&
                 DeserializeItem(Items[value.Id]) is IItemWithEtag existingItemWithEtag &&
                 !ignoreEtag

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
@@ -562,6 +562,31 @@ namespace Microsoft.Azure.CosmosRepositoryTests
         }
 
         [Fact]
+        public async Task UpdateAsync_WhereValueEtagIsNull_Updates()
+        {
+            //Arrange
+            string originalEtag = Guid.NewGuid().ToString();
+            Person item = new("joe") { Id = Guid.NewGuid().ToString(), Type = nameof(Person), Etag = originalEtag };
+            _personRepository.Items.TryAddAsJson(item.Id, item);
+            Person updateItem = new("joe2") { Id = item.Id, Type = nameof(Person), Etag = null! };
+
+            //Act
+            Person person = await _personRepository.UpdateAsync(updateItem, default, false);
+
+            Person addedPerson = _personRepository.DeserializeItem(_personRepository.Items.Values.First());
+
+            Assert.Equal(updateItem.Name, person.Name);
+            Assert.Equal(updateItem.Id, person.Id);
+            Assert.Equal(updateItem.Type, person.Type);
+
+            Assert.Equal(updateItem.Name, addedPerson.Name);
+            Assert.Equal(updateItem.Id, addedPerson.Id);
+            Assert.Equal(updateItem.Type, addedPerson.Type);
+
+            Assert.True(!string.IsNullOrWhiteSpace(addedPerson.Etag) && addedPerson.Etag != Guid.Empty.ToString() && addedPerson.Etag != originalEtag);
+        }
+
+        [Fact]
         public async Task UpdateAsync_ManyItems_UpdatesAllItems()
         {
             //Arrange


### PR DESCRIPTION
Updated the in memory repository to reflect the real behaviour when upserting items.

Added the ability to set the etag in the constructor this will allow the items to be mapped to and from other objects without losing this data.

# Breaking Changes
- Changed item with etag to be abstract