### PR TITLE
Update paging methods to be opt in for returning count information

### DIFF
--- a/samples/Paging/Program.cs
+++ b/samples/Paging/Program.cs
@@ -32,8 +32,8 @@ await BasicScrollingAsync();
 async Task BasicPageAsync()
 {
     double totalCharge = 0;
-    IPageQueryResult<Person> page = await repository.PageAsync(pageNumber: 1,pageSize: 25);
-    while (page.HasNextPage)
+    IPageQueryResult<Person> page = await repository.PageAsync(pageNumber: 1,pageSize: 25, returnTotal:true);
+    while (page.HasNextPage is not null && page.HasNextPage.Value)
     {
         foreach (Person person in page.Items)
         {

--- a/samples/Specification/FullSpecificationSamples.cs
+++ b/samples/Specification/FullSpecificationSamples.cs
@@ -48,7 +48,7 @@ public class FullSpecificationSamples
 
         UsersOrderByAgeOffsetSpecification specification = new(age);
         IPageQueryResult<Person> page = await _repository.QueryAsync(specification);
-        while (page.HasNextPage)
+        while (page.HasNextPage is not null && page.HasNextPage.Value)
         {
             foreach (Person person in page.Items)
             {

--- a/samples/Specification/SpecificationPagingSamples.cs
+++ b/samples/Specification/SpecificationPagingSamples.cs
@@ -25,7 +25,7 @@ public class SpecificationPagingSamples
         double totalCharge = 0;
         OffsetByPageNumberSpecification<Person> specification = new(1, 25);
         IPageQueryResult<Person> page = await _repository.QueryAsync(specification);
-        while (page.HasNextPage)
+        while (page.HasNextPage is not null && page.HasNextPage.Value)
         {
             foreach (Person person in page.Items)
             {

--- a/src/Microsoft.Azure.CosmosRepository/DefaultRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/DefaultRepository.cs
@@ -370,6 +370,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageSize = 25,
             string? continuationToken = null,
+            bool returnTotal = false,
             CancellationToken cancellationToken = default)
         {
             Container container = await _containerProvider.GetContainerAsync().ConfigureAwait(false);
@@ -379,7 +380,6 @@ namespace Microsoft.Azure.CosmosRepository
                 MaxItemCount = pageSize
             };
 
-
             IQueryable<TItem> query = container
                 .GetItemLinqQueryable<TItem>(requestOptions: options, continuationToken: continuationToken)
                 .Where(_repositoryExpressionProvider.Build(predicate ??
@@ -387,7 +387,11 @@ namespace Microsoft.Azure.CosmosRepository
 
             _logger.LogQueryConstructed(query);
 
-            Response<int> countResponse = await query.CountAsync(cancellationToken);
+            Response<int>? countResponse = null;
+            if (returnTotal)
+            {
+                countResponse = await query.CountAsync(cancellationToken);
+            }
 
             (List<TItem> Items, double Charge, string? ContinuationToken) result =
                 await GetAllItemsAsync(query, pageSize, cancellationToken);
@@ -395,10 +399,10 @@ namespace Microsoft.Azure.CosmosRepository
             _logger.LogQueryExecuted(query, result.Charge);
 
             return new Page<TItem>(
-                countResponse.Resource,
+                countResponse?.Resource ?? null,
                 pageSize,
                 result.Items.AsReadOnly(),
-                result.Charge + countResponse.RequestCharge,
+                result.Charge + countResponse?.RequestCharge ?? 0,
                 result.ContinuationToken);
         }
 
@@ -407,6 +411,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageNumber = 1,
             int pageSize = 25,
+            bool returnTotal = false,
             CancellationToken cancellationToken = default)
         {
             Container container = await _containerProvider.GetContainerAsync().ConfigureAwait(false);
@@ -416,8 +421,11 @@ namespace Microsoft.Azure.CosmosRepository
                 .Where(_repositoryExpressionProvider
                     .Build(predicate ?? _repositoryExpressionProvider.Default<TItem>()));
 
-            Response<int> countResponse =
-                await query.CountAsync(cancellationToken).ConfigureAwait(false);
+            Response<int>? countResponse = null;
+            if (returnTotal)
+            {
+                countResponse = await query.CountAsync(cancellationToken);
+            }
 
             query = query.Skip(pageSize * (pageNumber - 1))
                 .Take(pageSize);
@@ -430,11 +438,11 @@ namespace Microsoft.Azure.CosmosRepository
             _logger.LogQueryExecuted(query, result.Charge);
 
             return new PageQueryResult<TItem>(
-                countResponse.Resource,
+                countResponse?.Resource ?? null,
                 pageNumber,
                 pageSize,
                 result.Items.AsReadOnly(),
-                result.Charge + countResponse.RequestCharge);
+                result.Charge + countResponse?.RequestCharge ?? 0);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Azure.CosmosRepository/DefaultRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/DefaultRepository.cs
@@ -388,6 +388,7 @@ namespace Microsoft.Azure.CosmosRepository
             _logger.LogQueryConstructed(query);
 
             Response<int>? countResponse = null;
+            
             if (returnTotal)
             {
                 countResponse = await query.CountAsync(cancellationToken);
@@ -422,6 +423,7 @@ namespace Microsoft.Azure.CosmosRepository
                     .Build(predicate ?? _repositoryExpressionProvider.Default<TItem>()));
 
             Response<int>? countResponse = null;
+            
             if (returnTotal)
             {
                 countResponse = await query.CountAsync(cancellationToken);

--- a/src/Microsoft.Azure.CosmosRepository/IRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/IRepository.cs
@@ -258,6 +258,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
         /// <param name="pageSize">The size of the page to return from cosmos db.</param>
         /// <param name="continuationToken">The token returned from a previous query, if null starts at the beginning of the data</param>
+        /// <param name="returnTotal">Specifies whether or not to return the total number of items that matched the query. This defaults to false as it can be a very expensive operation.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
         /// <returns>A <see cref="IPage{T}"/> of <see cref="IItem"/>s</returns>
         /// <remarks>This method makes use of cosmos dbs continuation tokens for efficient, cost effective paging utilising low RUs</remarks>
@@ -265,6 +266,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageSize = 25,
             string? continuationToken = null,
+            bool returnTotal=false,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -292,6 +294,7 @@ namespace Microsoft.Azure.CosmosRepository
         /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
         /// <param name="pageNumber">The page number to return from cosmos db.</param>
         /// <param name="pageSize">The size of the page to return from cosmos db.</param>
+        /// <param name="returnTotal">Specifies whether or not to return the total number of items that matched the query. This defaults to false as it can be a very expensive operation.</param>
         /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
         /// <returns>A <see cref="IPageQueryResult{T}"/> of <see cref="IItem"/>s</returns>
         /// <remarks>This method makes use of Cosmos DB's continuation tokens for efficient, cost effective paging utilizing low RUs</remarks>
@@ -300,6 +303,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageNumber = 1,
             int pageSize = 25,
+            bool returnTotal=false,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/InMemoryRepository.cs
@@ -358,6 +358,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageSize = 25,
             string? continuationToken = null,
+            bool returnTotal = false,
             CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
@@ -368,6 +369,7 @@ namespace Microsoft.Azure.CosmosRepository
             Expression<Func<TItem, bool>>? predicate = null,
             int pageNumber = 1,
             int pageSize = 25,
+            bool returnTotal = false,
             CancellationToken cancellationToken = default)
         {
             await Task.CompletedTask;
@@ -390,7 +392,7 @@ namespace Microsoft.Azure.CosmosRepository
                 .Take(pageSize);
 
             return new PageQueryResult<TItem>(
-                enumerable.Count(),
+                returnTotal ? enumerable.Count() : null,
                 pageNumber,
                 pageSize,
                 items.ToList().AsReadOnly(),

--- a/src/Microsoft.Azure.CosmosRepository/Paging/IPage.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Paging/IPage.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <summary>
         /// The total amount items that matched the query.
         /// </summary>
-        int Total { get; }
+        int? Total { get; }
 
         /// <summary>
         /// The size of the current page.
         /// </summary>
         int Size { get; }
 
-    
+
 
         /// <summary>
         /// The continuation token used to load results from a stateless marker.

--- a/src/Microsoft.Azure.CosmosRepository/Paging/IPageQueryResult.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Paging/IPageQueryResult.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <summary>
         /// The total amount pages that matched the query.
         /// </summary>
-        int TotalPages { get; }
+        int? TotalPages { get; }
 
         /// <summary>
         /// The total amount items that matched the query.
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <summary>
         /// Gets a value indicating whether the are next pages.
         /// </summary>
-        bool HasNextPage { get; }
+        bool? HasNextPage { get; }
 
         /// <summary>
         /// Gets a value indicating whether the are previous pages.
@@ -39,6 +39,6 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <summary>
         /// The next page number.
         /// </summary>
-        int NextPageNumber { get; }
+        int? NextPageNumber { get; }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Paging/Page.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Paging/Page.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <param name="items"></param>
         /// <param name="charge"></param>
         /// <param name="continuation"></param>
-        internal Page(int total, int size, IReadOnlyList<T> items, double charge, string? continuation = null)
+        internal Page(int? total, int size, IReadOnlyList<T> items, double charge, string? continuation = null)
         {
             Total = total;
             Size = size;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         }
 
         /// <inheritdoc />
-        public int Total { get; }
+        public int? Total { get; }
 
         /// <inheritdoc />
         public int Size { get; }

--- a/src/Microsoft.Azure.CosmosRepository/Paging/PageQueryResult.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Paging/PageQueryResult.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <param name="charge">The charge.</param>
         /// <param name="continuation">The continuation.</param>
         internal PageQueryResult(
-            int total,
+            int? total,
             int size,
             IReadOnlyList<T> items,
             double charge,
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         /// <param name="charge">The charge.</param>
         /// <param name="continuation">The continuation.</param>
         internal PageQueryResult(
-            int total,
+            int? total,
             int? pageNumber,
             int size,
             IReadOnlyList<T> items,
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         }
 
         /// <inheritdoc />
-        public int TotalPages => GetTotalPages();
+        public int? TotalPages => GetTotalPages();
 
         /// <inheritdoc />
         public int? PageNumber { get; }
@@ -58,22 +58,32 @@ namespace Microsoft.Azure.CosmosRepository.Paging
         public bool HasPreviousPage => PageNumber > 1;
 
         /// <inheritdoc />
-        public bool HasNextPage => PageNumber < TotalPages;
+        public bool? HasNextPage => TotalPages is not null ? PageNumber < TotalPages : null;
 
         /// <inheritdoc />
         public int PreviousPageNumber => GetPreviousPageNumber();
 
         /// <inheritdoc />
-        public int NextPageNumber => GetNextPageNumber();
+        public int? NextPageNumber => GetNextPageNumber();
 
-        private int GetNextPageNumber()
+        private int? GetNextPageNumber()
         {
-            return HasNextPage && PageNumber.HasValue ? PageNumber.Value + 1 : TotalPages;
+            if (HasNextPage is not null)
+            {
+                return HasNextPage.HasValue && PageNumber.HasValue ? PageNumber.Value + 1 : TotalPages ?? null;
+            }
+
+            return null;
         }
 
-        private int GetTotalPages()
+        private int? GetTotalPages()
         {
-            return (int)Math.Abs(Math.Ceiling(Total / (double)Size));
+            if (Total is not null)
+            {
+                return (int)Math.Abs(Math.Ceiling(Total.Value / (double)Size));
+            }
+
+            return null;
         }
 
         private int GetPreviousPageNumber()

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests
         }
 
         [Fact]
-        public async Task PageAsync_PredicateThatDoesMatch_ReturnsItemInList()
+        public async Task PageAsync_ReturnTotalIsFalse_ReturnsCorrectItemsAndTotalIsNullAndCountHasNotBeenCalled()
         {
             //Arrange
             Dog dog1 = new("cocker spaniel");
@@ -1005,10 +1005,10 @@ namespace Microsoft.Azure.CosmosRepositoryTests
             int pageNumber = 2;
 
             List<Dog> expectedList = _dogRepository.Items.Select(d => JsonConvert.DeserializeObject<Dog>(d.Value))
-                                                         .Where(d => d.Breed == "cocker spaniel")
-                                                         .Skip(pageSize * (pageNumber - 1))
-                                                         .Take(pageSize)
-                                                         .ToList();
+                .Where(d => d.Breed == "cocker spaniel")
+                .Skip(pageSize * (pageNumber - 1))
+                .Take(pageSize)
+                .ToList();
 
             //Act
             IPageQueryResult<Dog> dogs = await _dogRepository.PageAsync(d => d.Breed == "cocker spaniel", pageNumber, pageSize);
@@ -1017,11 +1017,54 @@ namespace Microsoft.Azure.CosmosRepositoryTests
             List<Dog> enumerable = dogs.Items.ToList();
             Assert.True(enumerable.Any());
             Assert.Equal(expectedList, enumerable, new DogComparer());
+            Assert.Equal(dogs.PageNumber, pageNumber);
             Assert.True(dogs.HasPreviousPage);
             Assert.Equal(1, dogs.PreviousPageNumber);
-            Assert.True(dogs.HasNextPage);
-            Assert.Equal(3, dogs.NextPageNumber);
-            Assert.Equal(3, dogs.TotalPages);
+            Assert.True(dogs.TotalPages is null);
+            Assert.True(dogs.NextPageNumber is null);
+            Assert.True(dogs.HasNextPage is null);
+        }
+
+        [Fact]
+        public async Task PageAsync_ReturnTotalIsTrue_ReturnsCorrectItemsAndTotalIsNotNull()
+        {
+            //Arrange
+            Dog dog1 = new("cocker spaniel");
+            Dog dog2 = new("cocker spaniel");
+            Dog dog3 = new("cocker spaniel");
+            Dog dog4 = new("cocker spaniel");
+            Dog dog5 = new("cocker spaniel");
+            Dog dog6 = new("cocker spaniel");
+            Dog dog7 = new("golden retriever");
+            _dogRepository.Items.TryAddAsJson(dog1.Id, dog1);
+            _dogRepository.Items.TryAddAsJson(dog2.Id, dog2);
+            _dogRepository.Items.TryAddAsJson(dog3.Id, dog3);
+            _dogRepository.Items.TryAddAsJson(dog4.Id, dog4);
+            _dogRepository.Items.TryAddAsJson(dog5.Id, dog5);
+            _dogRepository.Items.TryAddAsJson(dog6.Id, dog6);
+            _dogRepository.Items.TryAddAsJson(dog7.Id, dog7);
+            int pageSize = 2;
+            int pageNumber = 2;
+
+            List<Dog> expectedList = _dogRepository.Items.Select(d => JsonConvert.DeserializeObject<Dog>(d.Value))
+                .Where(d => d.Breed == "cocker spaniel")
+                .Skip(pageSize * (pageNumber - 1))
+                .Take(pageSize)
+                .ToList();
+
+            //Act
+            IPageQueryResult<Dog> dogs = await _dogRepository.PageAsync(d => d.Breed == "cocker spaniel", pageNumber, pageSize);
+
+            //Assert
+            List<Dog> enumerable = dogs.Items.ToList();
+            Assert.True(enumerable.Any());
+            Assert.Equal(expectedList, enumerable, new DogComparer());
+            Assert.Equal(dogs.PageNumber, pageNumber);
+            Assert.True(dogs.HasPreviousPage);
+            Assert.Equal(1, dogs.PreviousPageNumber);
+            Assert.True(dogs.TotalPages is null);
+            Assert.True(dogs.NextPageNumber is null);
+            Assert.True(dogs.HasNextPage is null);
         }
 
         [Fact]
@@ -1040,7 +1083,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests
             DogSpecification specification = new("golden retriever", 2, 2);
 
             //Act
-            IPageQueryResult<Dog> dogs = await _dogRepository.PageAsync(d => d.Breed == "golden retriever", pageNumber, pageSize);
+            IPageQueryResult<Dog> dogs = await _dogRepository.PageAsync(d => d.Breed == "golden retriever", pageNumber, pageSize, true);
 
             //Assert
             List<Dog> enumerable = dogs.Items.ToList();

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.3.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.17" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
         <PackageReference Include="Moq" Version="4.16.0" />

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
@@ -9,10 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.17"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
-        <PackageReference Include="Moq" Version="4.16.0"/>
-        <PackageReference Include="xunit" Version="2.4.1"/>
+        <PackageReference Include="FluentAssertions" Version="6.3.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.17" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="Moq" Version="4.16.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -24,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Microsoft.Azure.CosmosRepository\Microsoft.Azure.CosmosRepository.csproj"/>
+        <ProjectReference Include="..\..\src\Microsoft.Azure.CosmosRepository\Microsoft.Azure.CosmosRepository.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Currently any paging requests (in this package) also make a count request, this can be very expensive to run and therefore shouldn't be ran be default but should be opt in.

https://stackoverflow.com/questions/27745346/get-record-count-in-azure-documentdb
> For example from the above thread: 
16,400 records in single partition consumes 535 RUs.  
[Youngjae](https://stackoverflow.com/users/361100/youngjae)
 [Jul 24, 2017 at 4:57](https://stackoverflow.com/questions/27745346/get-record-count-in-azure-documentdb#comment77508424_43560975)

# Breaking Changes
- Added default variable to opt out (by default) or returning the count information from paging queries.
    - This will require users who wish to get total count information to add an additional parameter to their calls.