### PR TITLE
Renaming, few extra methods, extra data available on projections.

### DIFF
--- a/samples/BasicEventSourcingSample/Projections/ShipInformationProjections.cs
+++ b/samples/BasicEventSourcingSample/Projections/ShipInformationProjections.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using BasicEventSourcingSample.Core;
+using BasicEventSourcingSample.Infrastructure;
 using BasicEventSourcingSample.Projections.Models;
 using Microsoft.Azure.CosmosEventSourcing.Projections;
 using Microsoft.Azure.CosmosRepository;
@@ -10,7 +11,7 @@ namespace BasicEventSourcingSample.Projections;
 
 public class ShipInformationProjections
 {
-    public class ShipCreatedHandler : IEventProjectionHandler<ShipEvents.ShipCreated>
+    public class ShipCreatedHandler : IEventProjectionHandler<ShipEvents.ShipCreated, ShipEventSource>
     {
         private readonly IRepository<ShipInformation> _repository;
 
@@ -19,6 +20,7 @@ public class ShipInformationProjections
 
         public async ValueTask HandleAsync(
             ShipEvents.ShipCreated shipCreated,
+            ShipEventSource eventSource,
             CancellationToken cancellationToken = default)
         {
             ShipInformation info = new(
@@ -30,7 +32,7 @@ public class ShipInformationProjections
         }
     }
 
-    public class ShipDockedHandler : IEventProjectionHandler<ShipEvents.DockedInPort>
+    public class ShipDockedHandler : IEventProjectionHandler<ShipEvents.DockedInPort, ShipEventSource>
     {
         private readonly IRepository<ShipInformation> _repository;
 
@@ -39,6 +41,7 @@ public class ShipInformationProjections
 
         public async ValueTask HandleAsync(
             ShipEvents.DockedInPort dockedInPort,
+            ShipEventSource eventSource,
             CancellationToken cancellationToken = default)
         {
             (string name, string port, _) = dockedInPort;
@@ -54,7 +57,7 @@ public class ShipInformationProjections
         }
     }
 
-    public class ShipLoadedHandler : IEventProjectionHandler<ShipEvents.Loaded>
+    public class ShipLoadedHandler : IEventProjectionHandler<ShipEvents.Loaded, ShipEventSource>
     {
         private readonly IRepository<ShipInformation> _repository;
 
@@ -63,6 +66,7 @@ public class ShipInformationProjections
 
         public async ValueTask HandleAsync(
             ShipEvents.Loaded loaded,
+            ShipEventSource eventSource,
             CancellationToken cancellationToken = default)
         {
             (string name, string port, double cargoWeight, _) = loaded;

--- a/src/Microsoft.Azure.CosmosEventSourcing/Builders/DefaultCosmosEventSourcingBuilder.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Builders/DefaultCosmosEventSourcingBuilder.cs
@@ -73,7 +73,7 @@ internal class DefaultCosmosEventSourcingBuilder : ICosmosEventSourcingBuilder
         }
 
         _services.Scan(x => x.FromAssemblies(assemblies)
-            .AddClasses(classes => classes.AssignableTo(typeof(IEventProjectionHandler<>)))
+            .AddClasses(classes => classes.AssignableTo(typeof(IEventProjectionHandler<,>)))
             .AsImplementedInterfaces()
             .WithSingletonLifetime());
 

--- a/src/Microsoft.Azure.CosmosEventSourcing/Builders/ICosmosEventSourcingBuilder.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Builders/ICosmosEventSourcingBuilder.cs
@@ -27,7 +27,7 @@ public interface ICosmosEventSourcingBuilder
         where TProjectionBuilder : class, IEventSourceProjectionBuilder<TEventSource>;
 
     /// <summary>
-    /// Adds a projection builder that uses <see cref="IEventProjectionHandler{TEvent}"/>'s to project a single type of <see cref="IPersistedEvent"/>
+    /// Adds a projection builder that uses <see cref="IEventProjectionHandler{TEvent, TEventSource}"/>'s to project a single type of <see cref="IPersistedEvent"/>
     /// </summary>
     /// <param name="optionsAction">The <see cref="EventSourcingProcessorOptions{TEventSource}"/> used to configure the processor.</param>
     /// <typeparam name="TEventSource">The <see cref="EventSource"/></typeparam>
@@ -45,9 +45,9 @@ public interface ICosmosEventSourcingBuilder
         params Assembly[] assemblies);
 
     /// <summary>
-    /// Adds all of the <see cref="IEventProjectionHandler{TEvent}"/>'s provided in the given assemblies.
+    /// Adds all of the <see cref="IEventProjectionHandler{TEvent, TEventSource}"/>'s provided in the given assemblies.
     /// </summary>
-    /// <param name="assemblies">The assemblies to scan for <see cref="IEventProjectionHandler{TEvent}"/></param>
+    /// <param name="assemblies">The assemblies to scan for <see cref="IEventProjectionHandler{TEvent, TEventSource}"/></param>
     /// <returns></returns>
     public ICosmosEventSourcingBuilder AddAllEventProjectionHandlers(
         params Assembly[] assemblies);

--- a/src/Microsoft.Azure.CosmosEventSourcing/Extensions/EventSourceExtensions.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Extensions/EventSourceExtensions.cs
@@ -26,8 +26,8 @@ public static class EventSourceExtensions
     /// <returns>The TEvent instance.</returns>
     /// <remarks>If the event payload cannot be converted to the TEvent type null is returned.</remarks>
     public static TEvent? TryGetEventPayload<TEvent>(this EventSource eventSource)
-        where TEvent : class, IPersistedEvent
-        => eventSource.EventPayload switch
+        where TEvent : class, IPersistedEvent =>
+        eventSource.EventPayload switch
         {
             TEvent eventPayload => eventPayload,
             null => null,

--- a/src/Microsoft.Azure.CosmosEventSourcing/Extensions/EventSourceExtensions.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Extensions/EventSourceExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.CosmosEventSourcing.Extensions;
+
+/// <summary>
+/// A set of extension methods that can be used on an <see cref="EventSource"/>
+/// </summary>
+public static class EventSourceExtensions
+{
+    /// <summary>
+    /// Cast's the payload of an <see cref="EventSource"/> to a <see cref="IPersistedEvent"/>
+    /// </summary>
+    /// <param name="eventSource">The <see cref="EventSource"/> to read the payload from.</param>
+    /// <typeparam name="TEvent">The event type the payload will be cast to.</typeparam>
+    /// <returns>The TEvent instance.</returns>
+    public static TEvent GetEventPayload<TEvent>(this EventSource eventSource)
+        where TEvent : IPersistedEvent =>
+        (TEvent) eventSource.EventPayload;
+
+    /// <summary>
+    /// Cast's the payload of an <see cref="EventSource"/> to a <see cref="IPersistedEvent"/>
+    /// </summary>
+    /// <param name="eventSource">The <see cref="EventSource"/> to read the payload from.</param>
+    /// <typeparam name="TEvent">The event type the payload will be cast to.</typeparam>
+    /// <returns>The TEvent instance.</returns>
+    /// <remarks>If the event payload cannot be converted to the TEvent type null is returned.</remarks>
+    public static TEvent? TryGetEventPayload<TEvent>(this EventSource eventSource)
+        where TEvent : class, IPersistedEvent
+        => eventSource.EventPayload switch
+        {
+            TEvent eventPayload => eventPayload,
+            null => null,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+}

--- a/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ExpressionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ExpressionExtensions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.Azure.CosmosEventSourcing.Extensions;
+
+internal static class ExpressionExtensions
+{
+    internal static Expression<T> Compose<T>(
+        this Expression<T> first,
+        Expression<T> second,
+        Func<Expression, Expression, Expression> merge)
+    {
+        Dictionary<ParameterExpression, ParameterExpression> map =
+            first.Parameters
+                .Select((parameter, index) => (parameter, second: second.Parameters[index]))
+                .ToDictionary(p => p.second, p => p.parameter);
+
+        Expression secondBody = ParameterReBinder.ReplaceParameters(map, second.Body);
+
+        return Expression.Lambda<T>(merge(first.Body, secondBody), first.Parameters);
+    }
+
+    private class ParameterReBinder : ExpressionVisitor
+    {
+        private readonly Dictionary<ParameterExpression, ParameterExpression> _map;
+
+        private ParameterReBinder(Dictionary<ParameterExpression, ParameterExpression> map) =>
+            _map = map ?? new();
+
+        internal static Expression ReplaceParameters(
+            Dictionary<ParameterExpression, ParameterExpression> map, Expression exp) =>
+            new ParameterReBinder(map).Visit(exp)!;
+
+        /// <inheritdoc />
+        protected override Expression VisitParameter(ParameterExpression parameter)
+        {
+            if (_map.TryGetValue(parameter, out ParameterExpression replacement))
+            {
+                parameter = replacement;
+            }
+
+            return base.VisitParameter(parameter);
+        }
+    }
+}

--- a/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ServiceCollectionExtensions.cs
@@ -25,7 +25,7 @@ public static class ServiceCollectionExtensions
     {
         DefaultCosmosEventSourcingBuilder builder = new(services);
         eventSourcingBuilder.Invoke(builder);
-        services.AddSingleton(typeof(IEventSourceRepository<>), typeof(DefaultEventSourceRepository<>));
+        services.AddSingleton(typeof(IEventStore<>), typeof(DefaultEventStore<>));
         services.AddSingleton<IChangeFeedContainerProcessorProvider, DefaultEventSourcingProvider>();
         return services;
     }

--- a/src/Microsoft.Azure.CosmosEventSourcing/IEventStore.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/IEventStore.cs
@@ -1,13 +1,15 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq.Expressions;
+
 namespace Microsoft.Azure.CosmosEventSourcing;
 
 /// <summary>
-/// The repository responsible for managing the persistence of the an <see cref="EventSource"/>
+/// The class responsible for managing the persistence of the an <see cref="EventSource"/>
 /// </summary>
 /// <typeparam name="TEventSource"></typeparam>
-public interface IEventSourceRepository<TEventSource> where TEventSource : EventSource
+public interface IEventStore<TEventSource> where TEventSource : EventSource
 {
     /// <summary>
     /// Persists a set of <see cref="EventSource"/> records.
@@ -27,6 +29,18 @@ public interface IEventSourceRepository<TEventSource> where TEventSource : Event
     /// <returns></returns>
     ValueTask<IEnumerable<TEventSource>> ReadAsync(
         string partitionKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads all events for a given partition key.
+    /// </summary>
+    /// <param name="partitionKey">The value to use as the partition key in the query.</param>
+    /// <param name="predicate">A filter predicate to filter event on.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel this async request.</param>
+    /// <returns></returns>
+    ValueTask<IEnumerable<TEventSource>> ReadAsync(
+        string partitionKey,
+        Expression<Func<TEventSource, bool>> predicate,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/EventBasedEventSourceProjectionBuilder.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/EventBasedEventSourceProjectionBuilder.cs
@@ -30,6 +30,7 @@ internal class EventBasedEventSourceProjectionBuilder<TEventSource> : IEventSour
         {
             _logger.LogDebug("No IEventProjectionHandler<{EventType}> found",
                 payloadTypeName);
+
             return;
         }
 
@@ -38,7 +39,7 @@ internal class EventBasedEventSourceProjectionBuilder<TEventSource> : IEventSour
             try
             {
                 object? result = handlerType.GetMethod("HandleAsync")?
-                    .Invoke(handler, new object [] {sourcedEvent.EventPayload, cancellationToken});
+                    .Invoke(handler, new object[] {sourcedEvent.EventPayload, sourcedEvent, cancellationToken});
 
                 if (result is ValueTask valueTask)
                 {
@@ -57,5 +58,5 @@ internal class EventBasedEventSourceProjectionBuilder<TEventSource> : IEventSour
     }
 
     private static Type BuildEventProjectionHandlerType(TEventSource eventSource) =>
-        typeof(IEventProjectionHandler<>).MakeGenericType(eventSource.EventPayload.GetType());
+        typeof(IEventProjectionHandler<,>).MakeGenericType(eventSource.EventPayload.GetType(), eventSource.GetType());
 }

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/IEventProjectionHandler.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/IEventProjectionHandler.cs
@@ -6,17 +6,22 @@ namespace Microsoft.Azure.CosmosEventSourcing.Projections;
 /// <summary>
 /// Allows a projection to be built from a specific <see cref="IPersistedEvent"/> defined within an <see cref="EventSource"/>
 /// </summary>
-/// <typeparam name="TEvent"></typeparam>
-public interface IEventProjectionHandler<in TEvent> where TEvent : IPersistedEvent
+/// <typeparam name="TEvent">The type of <see cref="IPersistedEvent"/></typeparam>
+/// <typeparam name="TEventSource">The <see cref="EventSource"/>The event was part of</typeparam>
+public interface IEventProjectionHandler<in TEvent, in TEventSource>
+    where TEvent : IPersistedEvent
+    where TEventSource : EventSource
 {
     /// <summary>
     /// A method to process a new event after it has been saved into Cosmos.
     /// </summary>
     /// <remarks>This is invoked off the back fo the change feed processor library.</remarks>
     /// <param name="persistedEvent">The event that was written.</param>
+    /// <param name="eventSource">The event source with all it's properties</param>
     /// <param name="cancellationToken">A token used to cancel the async operation.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the async operation</returns>
     ValueTask HandleAsync(
         TEvent persistedEvent,
+        TEventSource eventSource,
         CancellationToken cancellationToken = default);
 }

--- a/tests/Microsoft.Azure.CosmosEventSourcingTests/EventStoreTests.cs
+++ b/tests/Microsoft.Azure.CosmosEventSourcingTests/EventStoreTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Microsoft.Azure.CosmosEventSourcingTests;
 
-public class EventSourceRepositoryTests
+public class EventStoreTests
 {
     private readonly AutoMocker _autoMocker = new();
     private readonly Mock<IRepository<Testing.SampleEventSource>> _repository;
@@ -31,17 +31,17 @@ public class EventSourceRepositoryTests
         new Testing.SampleEventSource(new Testing.SampleEvent(DateTime.UtcNow), Pk),
     };
 
-    public EventSourceRepositoryTests() =>
+    public EventStoreTests() =>
         _repository = _autoMocker.GetMock<IRepository<Testing.SampleEventSource>>();
 
-    private IEventSourceRepository<Testing.SampleEventSource> CreateSut() =>
-        _autoMocker.CreateInstance<DefaultEventSourceRepository<Testing.SampleEventSource>>();
+    private IEventStore<Testing.SampleEventSource> CreateSut() =>
+        _autoMocker.CreateInstance<DefaultEventStore<Testing.SampleEventSource>>();
 
     [Fact]
     public async Task PersistAsync_Events_SavesAllEvents()
     {
         //Arrange
-        IEventSourceRepository<Testing.SampleEventSource> sut = CreateSut();
+        IEventStore<Testing.SampleEventSource> sut = CreateSut();
 
         //Act
         await sut.PersistAsync(_events);
@@ -54,7 +54,7 @@ public class EventSourceRepositoryTests
     public async Task GetAsync_EventsInDb_GetsAllEvents()
     {
         //Arrange
-        IEventSourceRepository<Testing.SampleEventSource> sut = CreateSut();
+        IEventStore<Testing.SampleEventSource> sut = CreateSut();
 
         _repository
             .Setup(o =>
@@ -72,7 +72,7 @@ public class EventSourceRepositoryTests
     public async Task StreamAsync_EventsInDb_StreamsAllEvents()
     {
         //Arrange
-        IEventSourceRepository<Testing.SampleEventSource> sut = CreateSut();
+        IEventStore<Testing.SampleEventSource> sut = CreateSut();
 
         Page<Testing.SampleEventSource> page1 = new(
             null,


### PR DESCRIPTION
## Added EventSource to the projection builder

There may be common data stored on an `EventSource` that might not be on every `IPersistedEvent` which a user may want access to. This also allows access to the `Id` on the `EventSource` which could be used in an event inbox to stop duplicates being processed for example.

## Renamed `IEventSourceRepository<T>` -->  `IEventStore<T>`

I felt this better describes this as just a store of events and not an `IRepository<T>` as I feel you should always have a single container per set of events you are storing.

## Extra method to filter events

This could be useful pulling reports etc being able to find all of a given event or all of a set of events.