### PR TITLE
Added basic batch support

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Exceptions/BatchOperationException.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Exceptions/BatchOperationException.cs
@@ -1,0 +1,37 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using Microsoft.Azure.Cosmos;
+
+namespace Microsoft.Azure.CosmosRepository.Exceptions
+{
+    /// <summary>
+    /// Details an error when performing a batch operation for a given TItem
+    /// </summary>
+    /// <typeparam name="TItem"></typeparam>
+    public class BatchOperationException<TItem> : Exception
+        where TItem : IItem
+    {
+        /// <summary>
+        ///  The response from the batch operation.
+        /// </summary>
+        public TransactionalBatchResponse Response { get; }
+
+        /// <summary>
+        /// The status code return from the <see cref="TransactionalBatchResponse"/>
+        /// </summary>
+        public HttpStatusCode StatusCode => Response.StatusCode;
+
+        /// <summary>
+        /// Creates <see cref="BatchOperationException{TItem}"/>
+        /// </summary>
+        /// <param name="response"></param>
+        public BatchOperationException(TransactionalBatchResponse response) : base(
+            $"Failed to execute the batch operation for {typeof(TItem).Name}")
+        {
+            Response = response;
+        }
+    }
+}

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<ICosmosUniqueKeyPolicyProvider, DefaultCosmosUniqueKeyPolicyProvider>()
                 .AddSingleton(typeof(IReadOnlyRepository<>), typeof(DefaultRepository<>))
                 .AddSingleton(typeof(IWriteOnlyRepository<>), typeof(DefaultRepository<>))
+                .AddSingleton(typeof(IBatchRepository<>), typeof(DefaultRepository<>))
                 .AddSingleton(typeof(IRepository<>), typeof(DefaultRepository<>))
                 .AddSingleton<IRepositoryFactory, DefaultRepositoryFactory>()
                 .AddSingleton<ICosmosItemConfigurationProvider, DefaultCosmosItemConfigurationProvider>()

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.CosmosRepository.Extensions
+{
+    /// <summary>
+    /// A set of useful extension methods for a <see cref="ValueTask{TResult}"/>
+    /// </summary>
+    public static class ValueTaskExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="ValueTask"/> of <see cref="IEnumerable{T}"/> to a <see cref="List{T}"/>
+        /// </summary>
+        /// <param name="valueTask">The value task</param>
+        /// <typeparam name="T">The type of <see cref="IEnumerable{T}"/></typeparam>
+        /// <returns></returns>
+        public static async ValueTask<List<T>> ToListAsync<T>(this ValueTask<IEnumerable<T>> valueTask)
+        {
+            IEnumerable<T> e = await valueTask;
+            return e.ToList();
+        }
+    }
+}

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.CosmosRepository.Extensions
         /// <returns></returns>
         public static async ValueTask<List<T>> ToListAsync<T>(this ValueTask<IEnumerable<T>> valueTask)
         {
-            IEnumerable<T> e = await valueTask;
-            return e.ToList();
+            IEnumerable<T> items = await valueTask;
+            return items.ToList();
         }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ValueTaskExtensions.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.CosmosRepository.Extensions
         /// </summary>
         /// <param name="valueTask">The value task</param>
         /// <typeparam name="T">The type of <see cref="IEnumerable{T}"/></typeparam>
-        /// <returns></returns>
         public static async ValueTask<List<T>> ToListAsync<T>(this ValueTask<IEnumerable<T>> valueTask)
         {
             IEnumerable<T> items = await valueTask;

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Batch.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Batch.cs
@@ -1,0 +1,91 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.CosmosRepository.Exceptions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Azure.CosmosRepository
+{
+    internal partial class DefaultRepository<TItem>
+    {
+        /// <inheritdoc />
+        public async ValueTask UpdateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            List<TItem> list = items.ToList();
+
+            if (!list.Any())
+            {
+                throw new ArgumentException(
+                    "Unable to perform batch update with no items",
+                    nameof(items));
+            }
+
+            string partitionKey = list[0].PartitionKey;
+
+            Container container = await _containerProvider.GetContainerAsync();
+
+            TransactionalBatch batch = container.CreateTransactionalBatch(new PartitionKey(partitionKey));
+
+            foreach (TItem item in list)
+            {
+                TransactionalBatchItemRequestOptions options = new();
+
+                if (item is IItemWithEtag itemWithEtag)
+                {
+                    options.IfMatchEtag = itemWithEtag.Etag;
+                }
+
+                batch.UpsertItem(item, options);
+            }
+
+            using TransactionalBatchResponse response = await batch.ExecuteAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new BatchOperationException<TItem>(response);
+            }
+        }
+
+        /// <inheritdoc />
+        public async ValueTask CreateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            List<TItem> list = items.ToList();
+
+            if (!list.Any())
+            {
+                throw new ArgumentException(
+                    "Unable to perform batch create operation with no items",
+                    nameof(items));
+            }
+
+            string partitionKey = list[0].PartitionKey;
+
+            Container container = await _containerProvider.GetContainerAsync();
+
+            TransactionalBatch batch = container.CreateTransactionalBatch(new PartitionKey(partitionKey));
+
+            foreach (TItem item in list)
+            {
+                TransactionalBatchItemRequestOptions options = new();
+                batch.CreateItem(item);
+            }
+
+            using TransactionalBatchResponse response = await batch.ExecuteAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new BatchOperationException<TItem>(response);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
@@ -1,0 +1,55 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+// ReSharper disable once CheckNamespace
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.CosmosRepository
+{
+    /// <summary>
+    /// This is the batch enabled repository interface for any implementation of
+    /// <typeparamref name="TItem"/>, exposing asynchronous batch update and create functionality.
+    /// </summary>
+    /// <typeparam name="TItem">The <see cref="IItem"/> implementation class type.</typeparam>
+    /// <example>
+    /// With DI, use .ctor injection to require any implementation of <see cref="IItem"/>:
+    /// <code language="c#">
+    /// <![CDATA[
+    /// public class ConsumingService
+    /// {
+    ///     readonly IBatchRepository<SomePoco> _pocoRepository;
+    ///
+    ///     public ConsumingService(
+    ///         IBatchRepository<SomePoco> pocoRepository) =>
+    ///         _pocoRepository = pocoRepository;
+    /// }
+    /// ]]>
+    /// </code>
+    /// </example>
+    public interface IBatchRepository<in TItem>
+        where TItem : IItem
+    {
+        /// <summary>
+        /// Updates an <see cref="IEnumerable{TItem}"/> as a batch.
+        /// </summary>
+        /// <param name="items">The items to update.</param>
+        /// <param name="cancellationToken">A token to cancel the async operation.</param>
+        /// <returns></returns>
+        ValueTask UpdateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates an <see cref="IEnumerable{TItem}"/> as a batch.
+        /// </summary>
+        /// <param name="items">The items to create.</param>
+        /// <param name="cancellationToken">A token to cancel the async operation.</param>
+        /// <returns></returns>
+        ValueTask CreateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
@@ -51,5 +51,15 @@ namespace Microsoft.Azure.CosmosRepository
         ValueTask CreateAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes an <see cref="IEnumerable{TItem}"/> as a batch.
+        /// </summary>
+        /// <param name="items">The items to create.</param>
+        /// <param name="cancellationToken">A token to cancel the async operation.</param>
+        /// <returns></returns>
+        ValueTask DeleteAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IBatchRepository.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.CosmosRepository.Exceptions;
 
 namespace Microsoft.Azure.CosmosRepository
 {
@@ -37,7 +38,8 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="items">The items to update.</param>
         /// <param name="cancellationToken">A token to cancel the async operation.</param>
-        /// <returns></returns>
+        /// <exception cref="BatchOperationException{TItem}">Thrown when the batch operation fails</exception>
+        /// <returns>An <see cref="ValueTask"/> that represents the async batch operation.</returns>
         ValueTask UpdateAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default);
@@ -47,7 +49,8 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="items">The items to create.</param>
         /// <param name="cancellationToken">A token to cancel the async operation.</param>
-        /// <returns></returns>
+        /// <exception cref="BatchOperationException{TItem}">Thrown when the batch operation fails</exception>
+        /// <returns>An <see cref="ValueTask"/> that represents the async batch operation.</returns>
         ValueTask CreateAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default);
@@ -57,7 +60,8 @@ namespace Microsoft.Azure.CosmosRepository
         /// </summary>
         /// <param name="items">The items to create.</param>
         /// <param name="cancellationToken">A token to cancel the async operation.</param>
-        /// <returns></returns>
+        /// <exception cref="BatchOperationException{TItem}">Thrown when the batch operation fails</exception>
+        /// <returns>An <see cref="ValueTask"/> that represents the async batch operation.</returns>
         ValueTask DeleteAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default);

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IRepository.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Azure.CosmosRepository
     /// </example>
     public interface IRepository<TItem> :
         IReadOnlyRepository<TItem>,
-        IWriteOnlyRepository<TItem>
+        IWriteOnlyRepository<TItem>,
+        IBatchRepository<TItem>
         where TItem : IItem
     {
     }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.CosmosRepository.Specification.Evaluator;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Azure.CosmosRepository
 {
     /// <inheritdoc/>
@@ -447,5 +448,19 @@ namespace Microsoft.Azure.CosmosRepository
 
         private void MismatchedEtags() =>
             throw new CosmosException(string.Empty, HttpStatusCode.PreconditionFailed, 0, string.Empty, 0);
+
+        public ValueTask UpdateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask CreateAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -467,7 +467,10 @@ namespace Microsoft.Azure.CosmosRepository
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            foreach (var item in items)
+            {
+                await DeleteAsync(item);
+            }
         }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -453,9 +453,9 @@ namespace Microsoft.Azure.CosmosRepository
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            foreach (var item in items)
+            foreach (TItem? item in items)
             {
-                await UpdateAsync(item);
+                await UpdateAsync(item, cancellationToken);
             }
         }
 
@@ -463,19 +463,19 @@ namespace Microsoft.Azure.CosmosRepository
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            foreach (var item in items)
+            foreach (TItem? item in items)
             {
-                await CreateAsync(item);
+                await CreateAsync(item, cancellationToken);
             }
         }
 
-        public ValueTask DeleteAsBatchAsync(
+        public async ValueTask DeleteAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            foreach (var item in items)
+            foreach (TItem? item in items)
             {
-                await DeleteAsync(item);
+                await DeleteAsync(item, cancellationToken);
             }
         }
     }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -462,5 +462,12 @@ namespace Microsoft.Azure.CosmosRepository
         {
             throw new NotImplementedException();
         }
+
+        public ValueTask DeleteAsBatchAsync(
+            IEnumerable<TItem> items,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -449,11 +449,14 @@ namespace Microsoft.Azure.CosmosRepository
         private void MismatchedEtags() =>
             throw new CosmosException(string.Empty, HttpStatusCode.PreconditionFailed, 0, string.Empty, 0);
 
-        public ValueTask UpdateAsBatchAsync(
+        public async ValueTask UpdateAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            foreach (var item in items)
+            {
+                await UpdateAsync(item);
+            }
         }
 
         public async ValueTask CreateAsBatchAsync(

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -456,11 +456,14 @@ namespace Microsoft.Azure.CosmosRepository
             throw new NotImplementedException();
         }
 
-        public ValueTask CreateAsBatchAsync(
+        public async ValueTask CreateAsBatchAsync(
             IEnumerable<TItem> items,
             CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            foreach (var item in items)
+            {
+                await CreateAsync(item);
+            }
         }
 
         public ValueTask DeleteAsBatchAsync(

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/ChangeFeedBasicTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/ChangeFeedBasicTests.cs
@@ -76,7 +76,7 @@ public class ChangeFeedBasicTests : CosmosRepositoryAcceptanceTest
 
             await _ratingsRepository.CreateAsync(tvRating);
 
-            await WaitFor(1);
+            await WaitFor(3);
 
             IEnumerable<RatingByCategory> results = await _ratingsByCategoryRepository
                 .GetAsync(x => x.PartitionKey == TechnologyCategoryId &&

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
@@ -8,13 +8,14 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.CosmosRepository.Exceptions;
 using Microsoft.Azure.CosmosRepository.Extensions;
-using Microsoft.Azure.CosmosRepository.Options;
 using Microsoft.Azure.CosmosRepositoryAcceptanceTests.Models;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.CosmosRepositoryAcceptanceTests;
 
+[Trait("Category", "Acceptance")]
+[Trait("Type", "Functional")]
 public class TransactionalBatchTests : CosmosRepositoryAcceptanceTest
 {
     public TransactionalBatchTests(ITestOutputHelper testOutputHelper)

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
@@ -24,7 +24,7 @@ public class TransactionalBatchTests : CosmosRepositoryAcceptanceTest
     }
 
     [Fact]
-    public async Task BatchRepository_Items_BehavesCorreclty()
+    public async Task BatchRepository_Items_BehavesCorrectlty()
     {
         try
         {

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.CosmosRepository.Exceptions;
+using Microsoft.Azure.CosmosRepository.Extensions;
+using Microsoft.Azure.CosmosRepository.Options;
+using Microsoft.Azure.CosmosRepositoryAcceptanceTests.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.CosmosRepositoryAcceptanceTests;
+
+public class TransactionalBatchTests : CosmosRepositoryAcceptanceTest
+{
+    public TransactionalBatchTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper, DefaultTestRepositoryOptions)
+    {
+    }
+
+    [Fact]
+    public async Task BatchRepository_Items_BehavesCorreclty()
+    {
+        try
+        {
+            await GetClient().UseClientAsync(PruneDatabases);
+
+            StockInformation stockInformation = new(5, DateTime.UtcNow);
+
+            IEnumerable<Product> products = Enumerable.Range(0, 5).Select(x => new Product(
+                $"Product {x}",
+                TechnologyCategoryId,
+                500,
+                stockInformation)).ToList();
+
+            await _productsRepository.CreateAsBatchAsync(products);
+
+            List<Product> createdProducts =
+                await _productsRepository.GetAsync(x => x.PartitionKey == TechnologyCategoryId).ToListAsync();
+
+            createdProducts.Count.Should().Be(5);
+            createdProducts.Should().BeEquivalentTo(products, x =>
+                x.Excluding(p => p.Etag)
+                    .Excluding(p => p.CreatedTimeUtc)
+                    .Excluding(p => p.LastUpdatedTimeRaw)
+                    .Excluding(p => p.LastUpdatedTimeUtc));
+
+            foreach (Product product in createdProducts)
+            {
+                product.Price++;
+            }
+
+            await _productsRepository.UpdateAsBatchAsync(createdProducts);
+
+            List<Product> updatedProducts =
+                await _productsRepository.GetAsync(x => x.PartitionKey == TechnologyCategoryId).ToListAsync();
+
+            updatedProducts.Count.Should().Be(5);
+            updatedProducts.Should().BeEquivalentTo(createdProducts, x =>
+                x.Excluding(p => p.Etag)
+                    .Excluding(p => p.CreatedTimeUtc)
+                    .Excluding(p => p.LastUpdatedTimeRaw)
+                    .Excluding(p => p.LastUpdatedTimeUtc));
+
+            List<Product> productsWithNowOutOfDateEtags = createdProducts;
+
+            await Assert.ThrowsAsync<BatchOperationException<Product>>(() =>
+                _productsRepository.UpdateAsBatchAsync(productsWithNowOutOfDateEtags).AsTask());
+        }
+        finally
+        {
+            await GetClient().UseClientAsync(PruneDatabases);
+        }
+    }
+}

--- a/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryAcceptanceTests/TransactionalBatchTests.cs
@@ -70,6 +70,10 @@ public class TransactionalBatchTests : CosmosRepositoryAcceptanceTest
 
             await Assert.ThrowsAsync<BatchOperationException<Product>>(() =>
                 _productsRepository.UpdateAsBatchAsync(productsWithNowOutOfDateEtags).AsTask());
+
+            await _productsRepository.DeleteAsBatchAsync(updatedProducts);
+            int count = await _productsRepository.CountAsync(x => x.PartitionKey == TechnologyCategoryId);
+            count.Should().Be(0);
         }
         finally
         {


### PR DESCRIPTION
Related to #151 

This is the first pass and allows items to be created, updated, and deleted as of a batch.

I have plans for a builder of a kind that will allow items that share the same partition key to having some more flexible operations, building up a transaction which I also think will be very nice. This is a good start tho and will have its use cases.

I see this working well and a kind of stepping stone for the issue described here #224 