### PR TITLE
CosmosEventSourcing - Acceptance test turn off

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -80,17 +80,17 @@ jobs:
         run: |
           dotnet test --no-restore --verbosity normal --filter "Category=Acceptance&Type!=Container"
           
-      - name: Prune databases
-        working-directory: ./tools/CosmosTestHelper
-        env:
-          CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
-        run: dotnet run
+      #- name: Prune databases
+      #  working-directory: ./tools/CosmosTestHelper
+      #  env:
+       #   CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+       # run: dotnet run
 
-      - name: Test Cosmos Event Sourcing
-        env:
-          CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
-        run: |
-          dotnet test --no-restore --verbosity normal --filter "Category=Acceptance&Type=CosmosEventSourcing"
+      #- name: Test Cosmos Event Sourcing
+      #  env:
+         # CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+       # run: |
+        #  dotnet test --no-restore --verbosity normal --filter "Category=Acceptance&Type=CosmosEventSourcing"
           
       - name: Prune databases
         working-directory: ./tools/CosmosTestHelper

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -60,17 +60,17 @@ jobs:
             CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
           run: dotnet run
 
-        - name: Test Cosmos Event Sourcing
-          env:
-            CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
-          run: |
-            dotnet test --no-restore --verbosity normal --filter "Category=Acceptance&Type=CosmosEventSourcing"
+              #- name: Prune databases
+      #  working-directory: ./tools/CosmosTestHelper
+      #  env:
+       #   CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+       # run: dotnet run
 
-        - name: Prune databases
-          working-directory: ./tools/CosmosTestHelper
-          env:
-            CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
-          run: dotnet run
+      #- name: Test Cosmos Event Sourcing
+      #  env:
+         # CosmosConnectionString: ${{ secrets.COSMOS_INTEGRATION_TEST_CONNECTION_STRING }}
+       # run: |
+        #  dotnet test --no-restore --verbosity normal --filter "Category=Acceptance&Type=CosmosEventSourcing"
 
         - name: Test Container Creation
           env:


### PR DESCRIPTION
I have had to turn these off, for now, the tests require 3 containers, one for the events, one for the leases container for the change feed & one for the projections. This breaks the 1000 RU limit, I will look at setting up another account another time.