### PR TITLE
Fix ETag Bug with Batch Updates

### DIFF
--- a/src/Microsoft.Azure.CosmosEventSourcing/Aggregates/AggregateRoot.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Aggregates/AggregateRoot.cs
@@ -123,7 +123,7 @@ public abstract class AggregateRoot : IAggregateRoot
 
     private void CreateAtomicMarkerEvent()
     {
-        _atomicEvent = new AtomicEvent(Guid.NewGuid().ToString(), string.Empty) with
+        _atomicEvent = new AtomicEvent(nameof(AtomicEvent), Guid.NewGuid().ToString())
         {
             Sequence = int.MaxValue,
             OccuredUtc = DateTime.UtcNow

--- a/src/Microsoft.Azure.CosmosEventSourcing/Events/AtomicEvent.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Events/AtomicEvent.cs
@@ -25,9 +25,6 @@ public record class AtomicEvent : DomainEvent
         ETag = eTag;
     }
 
-    /// <summary>
-    ///
-    /// </summary>
     [JsonIgnore]
     internal string ETag { get; init; }
 }

--- a/src/Microsoft.Azure.CosmosEventSourcing/Events/AtomicEvent.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Events/AtomicEvent.cs
@@ -25,5 +25,9 @@ public record class AtomicEvent : DomainEvent
         ETag = eTag;
     }
 
+    /// <summary>
+    ///
+    /// </summary>
+    [JsonIgnore]
     internal string ETag { get; init; }
 }

--- a/tests/Microsoft.Azure.CosmosEventSourcingTests/Aggregates/AggregateRootTests.cs
+++ b/tests/Microsoft.Azure.CosmosEventSourcingTests/Aggregates/AggregateRootTests.cs
@@ -95,7 +95,7 @@ public class AggregateTests
 
         //Assert
         root.AtomicEvent.Should().NotBeNull();
-        root.AtomicEvent.ETag.Should().BeEmpty();
+        root.AtomicEvent.ETag.Should().NotBeEmpty();
         root.AtomicEvent.EventId.Should().NotBeEmpty();
         root.AtomicEvent.Sequence.Should().Be(int.MaxValue);
     }


### PR DESCRIPTION
We had an issue where the sequence number of events where being duplicated this was because of the Etags and optimistic concurrency not propagating properly between the `AggregateRoot` and the `EventItem` through the `AtomicEvent`'s.