### PR TITLE
Ability to opt out auto resource creation

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.CosmosRepository.Options
         public IItemContainerBuilder ContainerBuilder { get; } = new DefaultItemContainerBuilder();
 
         /// <summary>
-        /// Used to tell the SDK whether or not to try and creates databases & containers if they do not exist.
+        /// Used to tell the SDK whether or not to try and creates databases and containers if they do not exist.
         /// </summary>
         /// <remarks>This feature is very powerful for local development. However, in scenarios where infrastructure as code is used this may not be required.</remarks>
         public bool IsAutoResourceCreationIfNotExistsEnabled { get; set; } = true;

--- a/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
@@ -113,6 +113,12 @@ namespace Microsoft.Azure.CosmosRepository.Options
         public IItemContainerBuilder ContainerBuilder { get; } = new DefaultItemContainerBuilder();
 
         /// <summary>
+        /// Used to tell the SDK whether or not to try and creates databases & containers if they do not exist.
+        /// </summary>
+        /// <remarks>This feature is very powerful for local development. However, in scenarios where infrastructure as code is used this may not be required.</remarks>
+        public bool IsAutoResourceCreationIfNotExistsEnabled { get; set; } = true;
+
+        /// <summary>
         /// Container options provided by the <see cref="Builders.IItemContainerBuilder"/>
         /// </summary>
         internal IReadOnlyList<ContainerOptionsBuilder> ContainerOptions => ContainerBuilder.Options;


### PR DESCRIPTION
This defaults to the original behaviour of create if not exists. This is great for local dev and small projects.

Larger projects might use infrastructure as code to provision databases and containers. This means the create call is not needed. A small performance benefit can be gained from a read vs a create if not exists.

In addition if you were to use a managed identity to connect to cosmos DB. The create if not exists operation requires more permissions than just read so that can be another benefit.