### PR TITLE
Better error handling on non-deserializable event types - favor scoped handlers

### DIFF
--- a/docs/event-sourcing/src/projections/README.md
+++ b/docs/event-sourcing/src/projections/README.md
@@ -118,9 +118,6 @@ There are two keys point to take not of here. The fist is the processor name, th
 
 ## Handling Failures
 
-It is vitally important that exceptions thrown when processing an event from the change feed is handled properly by the consumer. Depending on the criticality of the role your projection is playing determines how you need to handle the failure of processing an event. 
+It is vitally important that exceptions thrown when processing an event from the change feed is handled properly by the consumer. Depending on the criticality of the role your projection is playing determines how you need to handle the failure of processing an event. The change feed processor library will retry changes infinitely that result in un-handled exceptions. This makes it even more important that non-transient errors handled and logged for manual intervention in the future.
 
-
-```csharp
-//TODO: Need to add more once the dead-letter container is implemented.
-```
+The library also is extremely careful when handling errors in it's part of the changes pipeline. The main place the library has to be careful is when deserializing it's events. The library will return a special event type in the case of a deserialization failure. The `NonDeserializableEvent` can be handled by a consumer projections and can provide relevant information, such as the payload as a JObject, the exception that caused the failure, or whether or not the types where just not registered.

--- a/src/Microsoft.Azure.CosmosEventSourcing/Builders/DefaultCosmosEventSourcingBuilder.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Builders/DefaultCosmosEventSourcingBuilder.cs
@@ -31,7 +31,7 @@ internal class DefaultCosmosEventSourcingBuilder : ICosmosEventSourcingBuilder
         optionsAction?.Invoke(options);
 
         _services.AddSingleton(options);
-        _services.AddSingleton<IEventItemProjection<TEventItem, TProjectionKey>, TProjection>();
+        _services.AddScoped<IEventItemProjection<TEventItem, TProjectionKey>, TProjection>();
         _services.AddSingleton<IEventSourcingProcessor, DefaultEventSourcingProcessor<TEventItem, TProjectionKey>>();
 
         return new EventItemProjectionBuilder<TEventItem, TProjectionKey>(
@@ -49,7 +49,7 @@ internal class DefaultCosmosEventSourcingBuilder : ICosmosEventSourcingBuilder
 
         _services.AddSingleton(options);
         _services
-            .AddSingleton<IEventItemProjection<TEventItem, TProjectionKey>, DefaultDomainEventProjection<TEventItem, TProjectionKey>>();
+            .AddScoped<IEventItemProjection<TEventItem, TProjectionKey>, DefaultDomainEventProjection<TEventItem, TProjectionKey>>();
         _services.AddSingleton<IEventSourcingProcessor, DefaultEventSourcingProcessor<TEventItem, TProjectionKey>>();
         return this;
     }
@@ -83,7 +83,7 @@ internal class DefaultCosmosEventSourcingBuilder : ICosmosEventSourcingBuilder
         _services.Scan(x => x.FromAssemblies(assemblies)
             .AddClasses(classes => classes.AssignableTo(typeof(IDomainEventProjection<,,>)))
             .AsImplementedInterfaces()
-            .WithSingletonLifetime());
+            .WithScopedLifetime());
 
         return this;
     }

--- a/src/Microsoft.Azure.CosmosEventSourcing/ChangeFeed/DefaultEventSourcingProcessor.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/ChangeFeed/DefaultEventSourcingProcessor.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.CosmosEventSourcing.Options;
 using Microsoft.Azure.CosmosEventSourcing.Projections;
 using Microsoft.Azure.CosmosRepository.ChangeFeed.Providers;
 using Microsoft.Azure.CosmosRepository.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.CosmosEventSourcing.ChangeFeed;
@@ -19,7 +20,7 @@ internal class DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey> : IE
     private readonly ICosmosContainerService _containerService;
     private readonly ILeaseContainerProvider _leaseContainerProvider;
     private readonly ILogger<DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey>> _logger;
-    private readonly IEventItemProjection<TSourcedEvent, TProjectionKey> _projection;
+    private readonly IServiceProvider _serviceProvider;
     private ChangeFeedProcessor? _processor;
 
     public DefaultEventSourcingProcessor(
@@ -27,13 +28,13 @@ internal class DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey> : IE
         ICosmosContainerService containerService,
         ILeaseContainerProvider leaseContainerProvider,
         ILogger<DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey>> logger,
-        IEventItemProjection<TSourcedEvent, TProjectionKey> projection)
+        IServiceProvider serviceProvider)
     {
         _options = options;
         _containerService = containerService;
         _leaseContainerProvider = leaseContainerProvider;
         _logger = logger;
-        _projection = projection;
+        _serviceProvider = serviceProvider;
     }
 
     public async Task StartAsync()
@@ -78,9 +79,13 @@ internal class DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey> : IE
 
         foreach (TSourcedEvent change in changes)
         {
+            using IServiceScope scope = _serviceProvider.CreateScope();
+            IEventItemProjection<TSourcedEvent, TProjectionKey> projection = scope.ServiceProvider
+                .GetRequiredService<IEventItemProjection<TSourcedEvent, TProjectionKey>>();
+
             try
             {
-                await _projection.ProjectAsync(change, cancellationToken);
+                await projection.ProjectAsync(change, cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Azure.CosmosEventSourcing/Converters/DomainEventConverter.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Converters/DomainEventConverter.cs
@@ -23,7 +23,17 @@ internal class DomainEventConverter : JsonConverter
         JToken? j = JToken.ReadFrom(reader);
         string? type = j["eventName"]?.ToString();
         type ??= j["EventName"]?.ToString();
-        Type payloadType = ConvertableTypes.First(x => x.Name == type);
+        Type? payloadType = ConvertableTypes.FirstOrDefault(x => x.Name == type);
+
+        if (payloadType is null)
+        {
+            return new NonDeserializableEvent
+            {
+                Name = type ?? "not-defined",
+                Payload = JObject.Parse(reader.ReadAsString())
+            };
+        }
+
         return j.ToObject(payloadType);
     }
 

--- a/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
@@ -1,6 +1,7 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.CosmosEventSourcing.Events;
@@ -19,4 +20,15 @@ public record NonDeserializableEvent : DomainEvent
     /// The payload of the event whose type could not be found
     /// </summary>
     public JObject Payload { get; init; } = JObject.FromObject(new {});
+
+    /// <summary>
+    /// An exception thrown as part of deserializing an event.
+    /// </summary>
+    public Exception? Exception { get; set; }
+
+    /// <summary>
+    /// The JSON reader that was used to try and deserialize the event.
+
+    /// </summary>
+    public JsonReader? JsonReader { get; set; }
 }

--- a/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
@@ -1,0 +1,22 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.CosmosEventSourcing.Events;
+
+/// <summary>
+/// This event is deserialized and presented in the place of an event that has not been configured for use by the custom JSON converter.
+/// </summary>
+public record NonDeserializableEvent : DomainEvent
+{
+    /// <summary>
+    /// The eventName value that could not be deserialized
+    /// </summary>
+    public string Name { get; init; } = "not-defined";
+
+    /// <summary>
+    /// The payload of the event whose type could not be found
+    /// </summary>
+    public JObject Payload { get; init; } = JObject.FromObject(new {});
+}

--- a/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Events/NonDeserializableEvent.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Azure.CosmosEventSourcing.Events;
 public record NonDeserializableEvent : DomainEvent
 {
     /// <summary>
-    /// The eventName value that could not be deserialized
+    /// The eventName value that could not be deserialized.
     /// </summary>
     public string Name { get; init; } = "not-defined";
 
     /// <summary>
-    /// The payload of the event whose type could not be found
+    /// The payload of the event whose type could not be found.
     /// </summary>
     public JObject Payload { get; init; } = JObject.FromObject(new {});
 
@@ -28,7 +28,6 @@ public record NonDeserializableEvent : DomainEvent
 
     /// <summary>
     /// The JSON reader that was used to try and deserialize the event.
-
     /// </summary>
     public JsonReader? JsonReader { get; set; }
 }

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
@@ -28,7 +28,8 @@ internal class
     {
         string payloadTypeName = eventItem.DomainEvent.GetType().Name;
         Type handlerType = BuildEventProjectionHandlerType(eventItem);
-        IEnumerable<object?> handlers = _serviceProvider.GetServices(handlerType).ToList();
+        using IServiceScope scope = _serviceProvider.CreateScope();
+        IEnumerable<object?> handlers = scope.ServiceProvider.GetServices(handlerType).ToList();
 
         if (handlers.Any() is false)
         {

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
@@ -32,21 +32,21 @@ internal class
 
         if (handlers.Any() is false)
         {
+            if (eventItem.DomainEvent is NonDeserializableEvent nonDeserializableEvent)
+            {
+                _logger.LogError(
+                    "The event with name {EventName} could not be deserialized as it was not registered with the custom deserializer payload = {EventPayload}",
+                    nonDeserializableEvent.Name,
+                    nonDeserializableEvent.Payload.ToString());
+                return;
+            }
+
             if (payloadTypeName is not nameof(AtomicEvent))
             {
                 _logger.LogDebug("No IDomainEventProjection<{EventType}> found",
                     payloadTypeName);
             }
 
-            return;
-        }
-
-        if (eventItem.DomainEvent is NonDeserializableEvent nonDeserializableEvent)
-        {
-            _logger.LogError(
-                "The event with name {EventName} could not be deserialized as it was not registered with the custom deserialiser payload = {EventPayload}",
-                nonDeserializableEvent.Name,
-                nonDeserializableEvent.Payload.ToString());
             return;
         }
 

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
@@ -44,7 +44,7 @@ internal class
         if (eventItem.DomainEvent is NonDeserializableEvent nonDeserializableEvent)
         {
             _logger.LogError(
-                "The event with name {EventName} could not be deserialized as it was not registered with the custom deserialized payload = {EventPayload}",
+                "The event with name {EventName} could not be deserialized as it was not registered with the custom deserialiser payload = {EventPayload}",
                 nonDeserializableEvent.Name,
                 nonDeserializableEvent.Payload.ToString());
             return;


### PR DESCRIPTION
- Support for a more robust deserialization routine using a new `NonDeserializableEvent` to let a consumer detect errors better.
- Support for scoped handlers (ahead of some correlation ID planned work)
- Docs on the new `NonDeserializableEvent` and how it is used, and why it is important to handle