### PR TITLE
Support correlation IDs and fix double scope being created

### DIFF
--- a/docs/event-sourcing/src/event-store/persistence/README.md
+++ b/docs/event-sourcing/src/event-store/persistence/README.md
@@ -62,3 +62,24 @@ As a consumer of this library there are a few ways to handle this exception grac
 :::warning Caution
 It is _important_ in any of the above solutions that the full operation is retried. i.e. read the new state of the aggregate and re-apply the new events on the _new_ version of the aggregate.
 :::
+
+## Correlation
+
+The event sourcing provider supports correlation IDs. These can be setup by consuming the scoped service `IContextService` and setting the `IContextService.CorrelationId` property. This will then be written into Cosmos DB for each event that was created in that context. This is also automatically populated when consuming changes from the change feed (projections).
+
+See below for some example middleware that makes use of the popular `CorrelationId` package for ASPNET CORE, to set a correlation ID for every HTTP request.
+
+```csharp
+app.Use(async (context, next) =>
+{
+    ICorrelationContextAccessor correlationContextAccessor =
+        context.RequestServices.GetRequiredService<ICorrelationContextAccessor>();
+    
+    IContextService contextService = context.RequestServices
+        .GetRequiredService<IContextService>();
+
+    contextService.CorrelationId = correlationContextAccessor.CorrelationContext.CorrelationId;
+
+    await next.Invoke();
+});
+```

--- a/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/BasicEventSourcingSample.csproj
+++ b/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/BasicEventSourcingSample.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="6.0.2" />
+      <PackageReference Include="CorrelationId" Version="3.0.1" />
       <PackageReference Include="Mumby0168.CleanArchitecture.Exceptions" Version="1.0.0" />
       <PackageReference Include="Mumby0168.CleanArchitecture.Exceptions.AspNetCore" Version="1.1.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />

--- a/samples/Microsoft.Azure.CosmosEventSourcing/EventSourcingJobsTracker/Program.cs
+++ b/samples/Microsoft.Azure.CosmosEventSourcing/EventSourcingJobsTracker/Program.cs
@@ -43,9 +43,9 @@ builder.Services.AddCosmosEventSourcing(eventSourcingBuilder =>
 builder.Services.AddCosmosRepositoryChangeFeedHostedService();
 
 builder.Services
-    .AddSingleton<IJobsTrackerService, DefaultJobsTrackerService>()
-    .AddSingleton<IJobListRepository, DefaultJobListRepository>()
-    .AddSingleton<IJobTrackerReadService, DefaultJobTrackerReadService>();
+    .AddScoped<IJobsTrackerService, DefaultJobsTrackerService>()
+    .AddScoped<IJobListRepository, DefaultJobListRepository>()
+    .AddScoped<IJobTrackerReadService, DefaultJobTrackerReadService>();
 
 
 WebApplication app = builder.Build();

--- a/src/Microsoft.Azure.CosmosEventSourcing/ChangeFeed/DefaultEventSourcingProcessor.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/ChangeFeed/DefaultEventSourcingProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices.Context;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.CosmosEventSourcing.Items;
 using Microsoft.Azure.CosmosEventSourcing.Options;
@@ -82,6 +83,9 @@ internal class DefaultEventSourcingProcessor<TSourcedEvent, TProjectionKey> : IE
             using IServiceScope scope = _serviceProvider.CreateScope();
             IEventItemProjection<TSourcedEvent, TProjectionKey> projection = scope.ServiceProvider
                 .GetRequiredService<IEventItemProjection<TSourcedEvent, TProjectionKey>>();
+
+            IContextService contextService = scope.ServiceProvider.GetRequiredService<IContextService>();
+            contextService.CorrelationId = change.CorrelationId;
 
             try
             {

--- a/src/Microsoft.Azure.CosmosEventSourcing/Context/DefaultContextService.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Context/DefaultContextService.cs
@@ -1,0 +1,11 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+namespace System.Runtime.CompilerServices.Context;
+
+/// <inheritdoc />
+public class DefaultContextService : IContextService
+{
+    /// <inheritdoc />
+    public string? CorrelationId { get; set; }
+}

--- a/src/Microsoft.Azure.CosmosEventSourcing/Context/IContextService.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Context/IContextService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) IEvangelist. All rights reserved.
+// Licensed under the MIT License.
+
+namespace System.Runtime.CompilerServices.Context;
+
+/// <summary>
+/// Allows context values to be set and retrieved for a given request/scope
+/// </summary>
+public interface IContextService
+{
+    /// <summary>
+    /// An ID that correlates a request/scope with an event.
+    /// </summary>
+    string? CorrelationId { get; set; }
+}

--- a/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices.Context;
 using Microsoft.Azure.CosmosEventSourcing.Builders;
 using Microsoft.Azure.CosmosEventSourcing.ChangeFeed;
 using Microsoft.Azure.CosmosEventSourcing.Converters;
@@ -29,9 +30,10 @@ public static class ServiceCollectionExtensions
         DefaultCosmosEventSourcingBuilder builder = new(services);
         DomainEventConverter.ConvertableTypes.Add(typeof(AtomicEvent));
         eventSourcingBuilder.Invoke(builder);
-        services.AddSingleton(typeof(IEventStore<>), typeof(DefaultEventStore<>));
-        services.AddSingleton(typeof(IWriteOnlyEventStore<>), typeof(DefaultEventStore<>));
-        services.AddSingleton(typeof(IReadOnlyEventStore<>), typeof(DefaultEventStore<>));
+        services.AddScoped<IContextService, DefaultContextService>();
+        services.AddScoped(typeof(IEventStore<>), typeof(DefaultEventStore<>));
+        services.AddScoped(typeof(IWriteOnlyEventStore<>), typeof(DefaultEventStore<>));
+        services.AddScoped(typeof(IReadOnlyEventStore<>), typeof(DefaultEventStore<>));
         services.AddSingleton<IChangeFeedContainerProcessorProvider, DefaultEventSourcingProvider>();
         return services;
     }

--- a/src/Microsoft.Azure.CosmosEventSourcing/Items/EventItem.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Items/EventItem.cs
@@ -19,7 +19,7 @@ public abstract class EventItem : IItemWithEtag, IItemWithTimeToLive
     private int? _timeToLive;
 
     private DomainEvent _domainEvent = null!;
-    private string? _etag = null!;
+    private string? _etag;
 
     /// <summary>
     /// The payload of the event to be stored.
@@ -53,7 +53,7 @@ public abstract class EventItem : IItemWithEtag, IItemWithTimeToLive
     public string Id { get; set; }
 
     /// <inheritdoc />
-    public string Type { get; set; } = null!;
+    public string Type { get; set; }
 
     /// <summary>
     /// The value used to partition the event.
@@ -88,6 +88,11 @@ public abstract class EventItem : IItemWithEtag, IItemWithTimeToLive
         get => _timeToLive.HasValue ? TimeSpan.FromSeconds(_timeToLive.Value) : null;
         set => _timeToLive = (int?) value?.TotalSeconds;
     }
+
+    /// <summary>
+    /// An ID that correlates a request/scope with an event.
+    /// </summary>
+    public string? CorrelationId { get; set; }
 
     /// <summary>
     /// Creates an <see cref="EventItem"/>

--- a/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Projections/DefaultDomainEventProjection.cs
@@ -28,8 +28,7 @@ internal class
     {
         string payloadTypeName = eventItem.DomainEvent.GetType().Name;
         Type handlerType = BuildEventProjectionHandlerType(eventItem);
-        using IServiceScope scope = _serviceProvider.CreateScope();
-        IEnumerable<object?> handlers = scope.ServiceProvider.GetServices(handlerType).ToList();
+        IEnumerable<object?> handlers = _serviceProvider.GetServices(handlerType).ToList();
 
         if (handlers.Any() is false)
         {

--- a/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Def.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Def.cs
@@ -1,6 +1,7 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices.Context;
 using Microsoft.Azure.CosmosEventSourcing.Items;
 using Microsoft.Azure.CosmosRepository;
 
@@ -11,12 +12,15 @@ internal partial class DefaultEventStore<TEventItem> :
 {
     private readonly IBatchRepository<TEventItem> _batchRepository;
     private readonly IReadOnlyRepository<TEventItem> _readOnlyRepository;
+    private readonly IContextService _contextService;
 
     public DefaultEventStore(
         IBatchRepository<TEventItem> batchRepository,
-        IReadOnlyRepository<TEventItem> readOnlyRepository)
+        IReadOnlyRepository<TEventItem> readOnlyRepository,
+        IContextService contextService)
     {
         _batchRepository = batchRepository;
         _readOnlyRepository = readOnlyRepository;
+        _contextService = contextService;
     }
 }

--- a/tests/Microsoft.Azure.CosmosEventSourcingTests/Stores/EventStoreTests.cs
+++ b/tests/Microsoft.Azure.CosmosEventSourcingTests/Stores/EventStoreTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices.Context;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.CosmosEventSourcing.Events;
@@ -22,6 +23,7 @@ public partial class EventStoreTests
     private readonly AutoMocker _autoMocker = new();
     private readonly Mock<IBatchRepository<Testing.SampleEventItem>> _batchRepository;
     private readonly Mock<IReadOnlyRepository<Testing.SampleEventItem>> _readonlyRepository;
+    private readonly Mock<IContextService> _contextService;
     private const string Pk = "pk";
 
     private readonly List<Testing.SampleEvent> _events = new()
@@ -56,6 +58,7 @@ public partial class EventStoreTests
     {
         _batchRepository = _autoMocker.GetMock<IBatchRepository<Testing.SampleEventItem>>();
         _readonlyRepository = _autoMocker.GetMock<IReadOnlyRepository<Testing.SampleEventItem>>();
+        _contextService = _autoMocker.GetMock<IContextService>();
     }
 
     private IEventStore<Testing.SampleEventItem> CreateSut() =>
@@ -75,6 +78,30 @@ public partial class EventStoreTests
             o.UpdateAsBatchAsync(
                 _eventItemsWithAtomicEvents,
                 default));
+    }
+
+    [Fact]
+    public async Task PersistAsync_EventsAndCorrelationId_SavesAllEventsWithCorrelationId()
+    {
+        //Arrange
+        IEventStore<Testing.SampleEventItem> sut = CreateSut();
+
+        string correlationId = Guid.NewGuid().ToString();
+        _contextService.SetupGet(o => o.CorrelationId).Returns(correlationId);
+
+        //Act
+        await sut.PersistAsync(_eventItemsWithAtomicEvents);
+
+        //Assert
+        _batchRepository.Verify(o =>
+            o.UpdateAsBatchAsync(
+                _eventItemsWithAtomicEvents,
+                default));
+
+        _eventItemsWithAtomicEvents
+            .Where(x => x.DomainEvent is not AtomicEvent)
+            .All(x => x.CorrelationId == correlationId)
+            .Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
1. Supports correlations ID's been written to events and stored within a scoped service
2. Remove the duplicate scope been created in `IDomainEventProjection`'s (it's already created before this is called)