### PR TITLE
Acknowledge serialization options of CosmosClient for PatchOperationBuilder

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.CosmosRepository.Builders
 
             return attributes.Length == 0
                 ? _namingStrategy.GetPropertyName(propertyInfo.Name, false)
-                : attributes.First().PropertyName;
+                : attributes[0].PropertyName;
         }
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -28,12 +28,10 @@ namespace Microsoft.Azure.CosmosRepository.Builders
             _namingStrategy = new CamelCaseNamingStrategy();
         }
 
-        public PatchOperationBuilder(CosmosPropertyNamingPolicy? cosmosPropertyNamingPolicy)
-        {
+        public PatchOperationBuilder(CosmosPropertyNamingPolicy? cosmosPropertyNamingPolicy) => 
             _namingStrategy = cosmosPropertyNamingPolicy == CosmosPropertyNamingPolicy.Default
                 ? new DefaultNamingStrategy()
                 : new CamelCaseNamingStrategy();
-        }
 
         public IPatchOperationBuilder<TItem> Replace<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value)
         {

--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.CosmosRepository.Builders
             JsonPropertyAttribute[] attributes =
                 propertyInfo.GetCustomAttributes<JsonPropertyAttribute>(true).ToArray();
 
-            return attributes.Length == 0
+            return attributes.Length is 0
                 ? _namingStrategy.GetPropertyName(propertyInfo.Name, false)
                 : attributes[0].PropertyName;
         }

--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -23,10 +23,8 @@ namespace Microsoft.Azure.CosmosRepository.Builders
 
         public IReadOnlyList<PatchOperation> PatchOperations => _patchOperations;
 
-        public PatchOperationBuilder()
-        {
+        public PatchOperationBuilder() =>
             _namingStrategy = new CamelCaseNamingStrategy();
-        }
 
         public PatchOperationBuilder(CosmosPropertyNamingPolicy? cosmosPropertyNamingPolicy) => 
             _namingStrategy = cosmosPropertyNamingPolicy == CosmosPropertyNamingPolicy.Default

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Update.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Update.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Azure.CosmosRepository
             CancellationToken cancellationToken = default,
             string? etag = default)
         {
-            IPatchOperationBuilder<TItem> patchOperationBuilder = new PatchOperationBuilder<TItem>();
+            CosmosPropertyNamingPolicy? propertyNamingPolicy =
+                _optionsMonitor.CurrentValue.SerializationOptions?.PropertyNamingPolicy;
+            IPatchOperationBuilder<TItem> patchOperationBuilder = new PatchOperationBuilder<TItem>(propertyNamingPolicy);
 
             builder(patchOperationBuilder);
 

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.CosmosRepository;
 using Microsoft.Azure.CosmosRepository.Builders;
@@ -46,7 +45,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
             builder.Replace(x => x.TestProperty, "100");
 
             //Assert
-            PatchOperation operation = builder.PatchOperations.First();
+            PatchOperation operation = builder.PatchOperations[0];
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
             Assert.Equal("/thisIsTheName", operation.Path);
         }
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
             builder.Replace(x => x.TestIntProperty, 50);
 
             //Assert
-            PatchOperation operation = builder.PatchOperations.First();
+            PatchOperation operation = builder.PatchOperations[0];
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
             Assert.Equal("/testIntProperty", operation.Path);
         }
@@ -76,7 +75,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
             builder.Replace(x => x.TestProperty, "Test Value");
 
             //Assert
-            PatchOperation operation = builder.PatchOperations.First();
+            PatchOperation operation = builder.PatchOperations[0];
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
             Assert.Equal("/testProperty", operation.Path);
         }
@@ -91,7 +90,7 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
             builder.Replace(x => x.TestProperty, "Test Value");
 
             //Assert
-            PatchOperation operation = builder.PatchOperations.First();
+            PatchOperation operation = builder.PatchOperations[0];
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
             Assert.Equal("/testProperty", operation.Path);
         }

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
@@ -1,12 +1,14 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.CosmosRepository;
 using Microsoft.Azure.CosmosRepository.Builders;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Xunit;
 
 namespace Microsoft.Azure.CosmosRepositoryTests.Builders
@@ -92,6 +94,42 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
             PatchOperation operation = builder.PatchOperations.First();
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
             Assert.Equal("/testProperty", operation.Path);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCases))]
+        public void AcknowledgeRepositorySerializationSettingForRetrievingPatchOperation(CosmosPropertyNamingPolicy? propertyNamingPolicy,
+            string expectedPropertyName)
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>(propertyNamingPolicy);
+
+            //Act
+            builder.Replace(x => x.TestIntProperty, 1234);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Replace, operation.OperationType);
+            Assert.Equal($"/{expectedPropertyName}", operation.Path);
+        }
+
+        public static IEnumerable<object?[]> GetTestCases()
+        {
+            yield return new object?[]
+            {
+                CosmosPropertyNamingPolicy.CamelCase,
+                new CamelCaseNamingStrategy().GetPropertyName(nameof(Item1.TestIntProperty), false)
+            };
+            yield return new object?[]
+            {
+                CosmosPropertyNamingPolicy.Default,
+                new DefaultNamingStrategy().GetPropertyName(nameof(Item1.TestIntProperty), false)
+            };
+            yield return new object?[]
+            {
+                null,
+                new CamelCaseNamingStrategy().GetPropertyName(nameof(Item1.TestIntProperty), false)
+            };
         }
     }
 }


### PR DESCRIPTION
This pr acknowledge the used serialization option of the cosmos client for the patch operation builder

- fixes #270