### PR TITLE
Expanding Patch Operations

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Builders/IPatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/IPatchOperationBuilder.cs
@@ -28,5 +28,73 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         /// <remarks>This currently only supports operations on properties on the root level of a JSON document,
         /// replacing properties on a nested object for example are currently not supported.</remarks>
         IPatchOperationBuilder<TItem> Replace<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be set with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being set.</typeparam>
+        /// <param name="expression">The expression to define which property to operate on.</param>
+        /// <param name="value">The value to set the property defined with.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Set<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be set with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of value to set.</typeparam>
+        /// <param name="path">The json document path</param>
+        /// <param name="value">The value to set.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Set<TValue>(string path, TValue? value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be added with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
+        /// <param name="expression">The expression to define which property to operate on.</param>
+        /// <param name="value">The value to add to the document</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Add<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be added with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
+        /// <param name="path">Target location reference.</param>
+        /// <param name="value">The value to add to the document</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Add<TValue>(string path, TValue? value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be removed with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being removed.</typeparam>
+        /// <param name="expression">The expression to define which property to operate on.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Remove<TValue>(Expression<Func<TItem, TValue>> expression);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be added with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
+        /// <param name="path">Target location reference.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Remove<TValue>(string path);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be incremented with the value provided.
+        /// </summary>
+        /// <param name="path">Target location reference.</param>
+        /// <param name="value">The value to add to the document.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Increment(string path, long value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be incremented with the value provided.
+        /// </summary>
+        /// <param name="path">Target location reference.</param>
+        /// <param name="value">The value to add to the document.</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Increment(string path, double value);
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Builders/IPatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/IPatchOperationBuilder.cs
@@ -30,6 +30,17 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         IPatchOperationBuilder<TItem> Replace<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value);
 
         /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be replaced with the value provided
+        /// </summary>
+        /// <param name="path">The path to replace</param>
+        /// <param name="value">The value to replace the property defined with.</param>
+        /// <typeparam name="TValue">The type of the property that is been replaced.</typeparam>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        /// <remarks>This currently only supports operations on properties on the root level of a JSON document,
+        /// replacing properties on a nested object for example are currently not supported.</remarks>
+        IPatchOperationBuilder<TItem> Replace<TValue>(string path, TValue value);
+
+        /// <summary>
         /// Allows a property of an <see cref="IItem"/> to be set with the value provided
         /// </summary>
         /// <typeparam name="TValue">The type of the property that is being set.</typeparam>
@@ -76,10 +87,9 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         /// <summary>
         /// Allows a property of an <see cref="IItem"/> to be added with the value provided
         /// </summary>
-        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
         /// <param name="path">Target location reference.</param>
         /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
-        IPatchOperationBuilder<TItem> Remove<TValue>(string path);
+        IPatchOperationBuilder<TItem> Remove(string path);
 
         /// <summary>
         /// Allows a property of an <see cref="IItem"/> to be incremented with the value provided.
@@ -90,11 +100,29 @@ namespace Microsoft.Azure.CosmosRepository.Builders
         IPatchOperationBuilder<TItem> Increment(string path, long value);
 
         /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be added with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
+        /// <param name="expression">The expression to define which property to operate on.</param>
+        /// <param name="value">The value to add to the document</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Increment<TValue>(Expression<Func<TItem, TValue>> expression, double value);
+
+        /// <summary>
         /// Allows a property of an <see cref="IItem"/> to be incremented with the value provided.
         /// </summary>
         /// <param name="path">Target location reference.</param>
-        /// <param name="value">The value to add to the document.</param>
+        /// <param name="value">The value to increment.</param>
         /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
         IPatchOperationBuilder<TItem> Increment(string path, double value);
+
+        /// <summary>
+        /// Allows a property of an <see cref="IItem"/> to be added with the value provided
+        /// </summary>
+        /// <typeparam name="TValue">The type of the property that is being added.</typeparam>
+        /// <param name="expression">The expression to define which property to operate on.</param>
+        /// <param name="value">The value to increment</param>
+        /// <returns>The same instance of <see cref="IPatchOperationBuilder{TItem}"/></returns>
+        IPatchOperationBuilder<TItem> Increment<TValue>(Expression<Func<TItem, TValue>> expression, long value);
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -40,6 +40,69 @@ namespace Microsoft.Azure.CosmosRepository.Builders
             return this;
         }
 
+        public IPatchOperationBuilder<TItem> Set<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value)
+        {
+            PropertyInfo property = expression.GetPropertyInfo();
+            string propertyToReplace = GetPropertyToReplace(property);
+            _rawPatchOperations.Add(new InternalPatchOperation(property, value, PatchOperationType.Set));
+            _patchOperations.Add(PatchOperation.Set($"/{propertyToReplace}", value));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Add<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value)
+        {
+            PropertyInfo property = expression.GetPropertyInfo();
+            string propertyToReplace = GetPropertyToReplace(property);
+            _rawPatchOperations.Add(new InternalPatchOperation(property, value, PatchOperationType.Replace));
+            _patchOperations.Add(PatchOperation.Add($"/{propertyToReplace}", value));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Set<TValue>(string path, TValue? value)
+        {
+            _patchOperations.Add(PatchOperation.Set($"/{path}", value));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Add<TValue>(string path, TValue? value)
+        {
+            _patchOperations.Add(PatchOperation.Add($"/{path}", value));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Remove<TValue>(Expression<Func<TItem, TValue>> expression)
+        {
+            PropertyInfo property = expression.GetPropertyInfo();
+            string propertyToReplace = GetPropertyToReplace(property);
+            _rawPatchOperations.Add(new InternalPatchOperation(property, null, PatchOperationType.Remove));
+            _patchOperations.Add(PatchOperation.Remove($"/{propertyToReplace}"));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Remove<TValue>(string path)
+        {
+            _patchOperations.Add(PatchOperation.Remove($"/{path}"));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Increment(string path, long value)
+        {
+            _patchOperations.Add(PatchOperation.Increment($"/{path}", value));
+            return this;
+        }
+
+        public IPatchOperationBuilder<TItem> Increment(string path, double value)
+        {
+            _patchOperations.Add(PatchOperation.Increment($"/{path}", value));
+            return this;
+        }
+
+        /// <summary>
+        /// Get the property name to replace. This only works for a single level of nesting.
+        /// </summary>
+        /// <remarks>If you're looking for nesting call the respective method with a given path instead.</remarks>
+        /// <param name="propertyInfo">The property to get the path of.</param>
+        /// <returns>Returns the path of the property name.</returns>
         private string GetPropertyToReplace(MemberInfo propertyInfo)
         {
             JsonPropertyAttribute[] attributes =

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Builders/PatchOperationBuilderTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) IEvangelist. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.CosmosRepository;
 using Microsoft.Azure.CosmosRepository.Builders;
@@ -36,7 +38,63 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
     public class PatchOperationBuilderTests
     {
         [Fact]
-        public void ReplaceGivenPropertyValueWithJsonAttributeSetsCorrectReplaceValue()
+        public void GetPropertyToReplaceGetsCorrectValueWithJsonAttribute()
+        {
+            //Arrange
+            PatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+            Expression<Func<Item1, string>> expression = item => item.TestProperty;
+
+            //Act
+            string path = builder.GetPropertyToReplace(expression);
+
+            //Assert
+            Assert.Equal("thisIsTheName", path);
+        }
+
+        [Fact]
+        public void GetPropertyToReplaceGetsCorrectValueWithNoAttributes()
+        {
+            //Arrange
+            PatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+            Expression<Func<Item1, int>> expression = item => item.TestIntProperty;
+
+            //Act
+            string path = builder.GetPropertyToReplace(expression);
+
+            //Assert
+            Assert.Equal("testIntProperty", path);
+        }
+
+        [Fact]
+        public void GetPropertyToReplaceGetsCorrectValueWithRequiredAttribute()
+        {
+            //Arrange
+            PatchOperationBuilder<RequiredItem> builder = new PatchOperationBuilder<RequiredItem>();
+            Expression<Func<RequiredItem, string>> expression = item => item.TestProperty;
+
+            //Act
+            string path = builder.GetPropertyToReplace(expression);
+
+            //Assert
+            Assert.Equal("testProperty", path);
+        }
+
+        [Fact]
+        public void GetPropertyToReplaceGetsCorrectValueWithRequiredAndJsonAttribute()
+        {
+            //Arrange
+            PatchOperationBuilder<RequiredAndJsonItem> builder = new PatchOperationBuilder<RequiredAndJsonItem>();
+            Expression<Func<RequiredAndJsonItem, string>> expression = item => item.TestProperty;
+
+            //Act
+            string path = builder.GetPropertyToReplace(expression);
+
+            //Assert
+            Assert.Equal("testProperty", path);
+        }
+
+        [Fact]
+        public void ReplaceGivenExpressionSetsCorrectPatchOperation()
         {
             //Arrange
             IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
@@ -51,48 +109,168 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Builders
         }
 
         [Fact]
-        public void ReplaceGivenPropertyWithNoAttributesSetsCorrectPatchOperation()
+        public void ReplaceGivenPathSetsCorrectPatchOperation()
         {
             //Arrange
             IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
 
             //Act
-            builder.Replace(x => x.TestIntProperty, 50);
+            builder.Replace("thisIsTheName", "100");
 
             //Assert
             PatchOperation operation = builder.PatchOperations[0];
             Assert.Equal(PatchOperationType.Replace, operation.OperationType);
-            Assert.Equal("/testIntProperty", operation.Path);
+            Assert.Equal("/thisIsTheName", operation.Path);
         }
 
         [Fact]
-        public void ReplaceGivenPropertyWithRequiredAttributeSetsCorrectPatchOperation()
+        public void SetGivenExpressionSetsCorrectPatchOperation()
         {
             //Arrange
-            IPatchOperationBuilder<RequiredItem> builder = new PatchOperationBuilder<RequiredItem>();
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
 
             //Act
-            builder.Replace(x => x.TestProperty, "Test Value");
+            builder.Set(x => x.TestProperty, "100");
 
             //Assert
             PatchOperation operation = builder.PatchOperations[0];
-            Assert.Equal(PatchOperationType.Replace, operation.OperationType);
-            Assert.Equal("/testProperty", operation.Path);
+            Assert.Equal(PatchOperationType.Set, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
         }
 
         [Fact]
-        public void ReplaceGivenPropertyWithRequiredAndJsonAttributesSetsCorrectPatchOperation()
+        public void SetGivenPathSetsCorrectPatchOperation()
         {
             //Arrange
-            IPatchOperationBuilder<RequiredAndJsonItem> builder = new PatchOperationBuilder<RequiredAndJsonItem>();
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
 
             //Act
-            builder.Replace(x => x.TestProperty, "Test Value");
+            builder.Set("thisIsTheName", "100");
 
             //Assert
             PatchOperation operation = builder.PatchOperations[0];
-            Assert.Equal(PatchOperationType.Replace, operation.OperationType);
-            Assert.Equal("/testProperty", operation.Path);
+            Assert.Equal(PatchOperationType.Set, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void AddGivenExpressionSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Add(x => x.TestProperty, "100");
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Add, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void AddGivenPathSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Add("thisIsTheName", "100");
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Add, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void RemoveGivenExpressionSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Remove(x => x.TestProperty);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Remove, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void RemoveGivenPathSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Remove("thisIsTheName");
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Remove, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void IncrementDoubleGivenExpressionSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Increment(x => x.TestProperty, 100.123);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Increment, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void IncrementDoubleGivenPathSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Increment("thisIsTheName", 100.123);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Increment, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void IncrementLongGivenExpressionSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Increment(x => x.TestProperty, 123456789);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Increment, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
+        }
+
+        [Fact]
+        public void IncrementLongGivenPathSetsCorrectPatchOperation()
+        {
+            //Arrange
+            IPatchOperationBuilder<Item1> builder = new PatchOperationBuilder<Item1>();
+
+            //Act
+            builder.Increment("thisIsTheName", 123456789);
+
+            //Assert
+            PatchOperation operation = builder.PatchOperations[0];
+            Assert.Equal(PatchOperationType.Increment, operation.OperationType);
+            Assert.Equal("/thisIsTheName", operation.Path);
         }
 
         [Theory]


### PR DESCRIPTION
This PR expands the patch operations to support Set, Add, Remove, and Increment.
 
@mumby0168 I understand this was assigned to you, I hope I am not stepping on your toes, this is just a draft to make sure I haven't overstepped, I will add tests after I know if this PR is needed.

I also had a question about the _rawPatchOperations is it needed?

Fixes #297 

