### PR TITLE
ignore timeToLive when null

### DIFF
--- a/src/Microsoft.Azure.CosmosEventSourcing/Items/EventItem.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Items/EventItem.cs
@@ -83,6 +83,7 @@ public abstract class EventItem : IItemWithEtag, IItemWithTimeToLive
     }
 
     /// <inheritdoc />
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public TimeSpan? TimeToLive
     {
         get => _timeToLive.HasValue ? TimeSpan.FromSeconds(_timeToLive.Value) : null;

--- a/src/Microsoft.Azure.CosmosRepository/FullItem.cs
+++ b/src/Microsoft.Azure.CosmosRepository/FullItem.cs
@@ -53,6 +53,7 @@ public abstract class FullItem : Item, IItemWithEtag, IItemWithTimeToLive, IItem
     public string? Etag { get; private set; }
 
     /// <inheritdoc />
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public TimeSpan? TimeToLive
     {
         get => _timeToLive.HasValue ? TimeSpan.FromSeconds(_timeToLive.Value) : null;

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Items/FullItemTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Items/FullItemTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using FluentAssertions;
+using Microsoft.Azure.CosmosRepositoryTests.Stubs;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Microsoft.Azure.CosmosRepositoryTests.Items;
+
+public class FullItemTests
+{
+    private readonly JsonSerializerSettings _jsonSerializerSettings = new()
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver()
+    };
+
+    [Fact]
+    public void FullItem_WithNullTimeToLive_SerializesCorrectly()
+    {
+        //Arrange
+        var etagValue = Guid.NewGuid().ToString();
+
+        TestItem item = new(etagValue);
+
+        //Act
+        var json = JsonConvert.SerializeObject(item, _jsonSerializerSettings);
+
+        //Assert
+        json.Should().Contain($"\"_etag\":\"{etagValue}\"");
+        json.Should().NotContain("timeToLive");
+        json.Should().NotContain("ttl");
+    }
+
+    [Fact]
+    public void FullItem_WithPopulatedTimeToLive_SerializesCorrectly()
+    {
+        //Arrange
+        var etagValue = Guid.NewGuid().ToString();
+
+        TestItem item = new(etagValue)
+        {
+            TimeToLive = TimeSpan.FromSeconds(10)
+        };
+
+        //Act
+        var json = JsonConvert.SerializeObject(item, _jsonSerializerSettings);
+
+        //Assert
+        json.Should().Contain($"\"_etag\":\"{etagValue}\"");
+        json.Should().Contain("\"timeToLive\":\"00:00:10\"");
+        json.Should().Contain("\"ttl\":10");
+    }
+}

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Microsoft.Azure.CosmosRepositoryTests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="Moq" Version="4.18.3" />

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Stubs/TestItem.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Stubs/TestItem.cs
@@ -7,5 +7,9 @@ namespace Microsoft.Azure.CosmosRepositoryTests.Stubs;
 
 public class TestItem : FullItem
 {
+    public TestItem() { }
+
+    public TestItem(string etag) : base(etag) { }
+
     public string Property { get; set; } = default!;
 }


### PR DESCRIPTION
Adds `NullValueHandling.Ignore` for the `TimeToLive` wrapper property on both `EventItem` and `FullItem`.

Addresses issue #314 