### PR TITLE
Improve exception messaging when there is no EventItemPartitionKey attribute explicitly defined

### DIFF
--- a/src/Microsoft.Azure.CosmosEventSourcing/Exceptions/EventItemPartitionKeyAttributeRequiredException.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Exceptions/EventItemPartitionKeyAttributeRequiredException.cs
@@ -15,7 +15,7 @@ public class EventItemPartitionKeyAttributeRequiredException : Exception
     /// </summary>
     /// <param name="aggregateType">Type of the aggregate which had the invalid configuration. Used to build up the message</param>
     public EventItemPartitionKeyAttributeRequiredException(Type aggregateType) :
-        base($"A {nameof(EventItemPartitionKeyAttribute)} must be present on a property in {aggregateType.Name}")
+        base($"A {nameof(EventItemPartitionKeyAttribute)} must be present on a property in {aggregateType.Name} or you must specify the partition key explicitly")
     {
 
     }


### PR DESCRIPTION
This one took my co-worker @mkercheval-tva hours to figure out because the message led him to believe that he was required to have an attribute identifying the partition key even though we already had another Aggregate type working without using that attribute which was confounding to him.

Problem turned out to be that he was calling the overload of PersistAsync (in DefaultEventStore.Write) where you don't explicitly specify the partition key.

Just a minor improvement that may save someone time.