### PR TITLE
[feat] Add health checks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,11 +16,10 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageVersion Include="xunit" Version="2.6.1" />
     <PackageVersion Include="Scrutor" Version="4.2.2" />
+    <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
   </ItemGroup>
   <!-- .NET 7.0. bits -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14" />
     <PackageVersion Include="IEvangelist.Azure.CosmosRepository" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.14" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
@@ -29,7 +28,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
@@ -48,8 +46,6 @@
   </ItemGroup>
   <!-- .NET 8.0. bits -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageVersion Include="IEvangelist.Azure.CosmosRepository" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
@@ -58,7 +54,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
@@ -84,7 +79,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
   <!-- .NET 7.0. bits -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14" />
     <PackageVersion Include="IEvangelist.Azure.CosmosRepository" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.14" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
@@ -48,6 +49,7 @@
   <!-- .NET 8.0. bits -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
     <PackageVersion Include="IEvangelist.Azure.CosmosRepository" Version="7.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />

--- a/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
+++ b/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
@@ -20,3 +20,9 @@ services.AddHealthChecks().AddCosmosRepository(assemblies: typeof(ExampleItem).A
 ```
 
 The Cosmos Repository Health package supports all of the existing functionality of Health Checks, such as failureStatus and tags, see the [Microsoft Documentation](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) for configuration details.
+
+Don't forget to map the health endpoint with:
+
+```csharp
+app.MapHealthChecks("/healthz");
+```

--- a/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
+++ b/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Health Checks"
+weight: 2
+---
+
+The `IEvangelist.Azure.CosmosRepository.AspNetCore` package adds support for [AspNet Core Health Checks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) using the [HealthChecks.CosmosDb](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.CosmosDb/README.md) package.
+
+## Setup
+
+To configure Cosmos DB health checks:  
+
+```csharp
+services.AddHealthChecks().AddCosmosRepository();
+```
+
+By default, this will scan all of the assemblies in your solution to locate the container names for each of your `IItem` types.  To refine this, and potentially reduce startup times, pass in the Assemblies containing your `IItem` types:
+
+```csharp
+services.AddHealthChecks().AddCosmosRepository(assemblies: typeof(ExampleItem).Assembly);
+```
+
+The Cosmos Repository Health package supports all of the existing functionality of Health Checks, such as failureStatus and tags, see the [Microsoft Documentation](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) for configuration details.

--- a/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/BasicEventSourcingSample.csproj
+++ b/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/BasicEventSourcingSample.csproj
@@ -13,7 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="7.0.0" />
       <PackageReference Include="CorrelationId" Version="3.0.1" />
       <PackageReference Include="Mumby0168.CleanArchitecture.Exceptions" Version="1.0.0" />
       <PackageReference Include="Mumby0168.CleanArchitecture.Exceptions.AspNetCore" Version="1.1.0" />

--- a/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/Program.cs
+++ b/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/Program.cs
@@ -13,13 +13,12 @@ using CorrelationId.DependencyInjection;
 using Microsoft.Azure.CosmosEventSourcing.Extensions;
 using Microsoft.Azure.CosmosEventSourcing.Stores;
 using Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
-using Microsoft.Azure.CosmosRepository.Extensions;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 IServiceCollection services = builder.Services;
 
 
-services.AddHealthChecks().AddCosmosDb(builder.Configuration.GetCosmosRepositoryConnectionString()!);
+services.AddHealthChecks().AddAzureCosmosDB();
 services.AddCleanArchitectureExceptionsHandler(options => options.ApplicationName = "EventSourcingShipSample");
 services.AddSwaggerGen();
 services.AddEndpointsApiExplorer();

--- a/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/Program.cs
+++ b/samples/Microsoft.Azure.CosmosEventSourcing/BasicEventSourcingSample/Program.cs
@@ -18,7 +18,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 IServiceCollection services = builder.Services;
 
 
-services.AddHealthChecks().AddAzureCosmosDB();
+services.AddHealthChecks().AddCosmosRepository();
 services.AddCleanArchitectureExceptionsHandler(options => options.ApplicationName = "EventSourcingShipSample");
 services.AddSwaggerGen();
 services.AddEndpointsApiExplorer();

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -1,35 +1,57 @@
 ﻿// Copyright (c) David Pine. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using HealthChecks.CosmosDb;
 using Microsoft.Azure.CosmosRepository.Options;
 using Microsoft.Azure.CosmosRepository.Providers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
 
 public static class HealthChecksBuilderExtensions
 {
-    //todo: add overloads to pass health check options (tags etc)
-    public static IHealthChecksBuilder AddAzureCosmosDB(this IHealthChecksBuilder builder)
+    /// <summary>
+    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
+    /// <param name="assemblies">The assemblies to scan for <see cref="IItem"/> types. Optional. If <c>null</c> types are discovered autimatically. Providing a assemblies to scan may reduce start up time.</param>
+    /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddCosmosRepository(this IHealthChecksBuilder builder,
+        Assembly[]? assemblies = null,
+        string? healthCheckName = "azure_cosmosdb",
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
     {
         builder.AddAzureCosmosDB(
             clientFactory: provider => provider.GetRequiredService<ICosmosClientProvider>().CosmosClient,
             optionsFactory: sp =>
             {
                 IOptions<RepositoryOptions> options = sp.GetRequiredService<IOptions<RepositoryOptions>>();
-                ICosmosItemConfigurationProvider itemConfigProvider = sp.GetRequiredService<ICosmosItemConfigurationProvider>();
-                IEnumerable<string> containers = itemConfigProvider.GetAllItemConfigurations().Select(i => i.ContainerName).Distinct();
+                ICosmosItemConfigurationProvider itemConfigProvider =
+                    sp.GetRequiredService<ICosmosItemConfigurationProvider>();
+                IEnumerable<string> containers = itemConfigProvider.GetAllItemConfigurations(assemblies)
+                    .Select(i => i.ContainerName).Distinct();
 
                 return new AzureCosmosDbHealthCheckOptions
                 {
                     DatabaseId = options.Value.DatabaseId,
                     ContainerIds = containers
                 };
-            });
+            }, healthCheckName, failureStatus, tags, timeout);
 
         return builder;
     }

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using HealthChecks.CosmosDb;
+using Microsoft.Azure.CosmosRepository.Options;
+using Microsoft.Azure.CosmosRepository.Providers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
+
+public static class HealthChecksBuilderExtensions
+{
+    //todo: add overloads to pass health check options (tags etc)
+    public static IHealthChecksBuilder AddAzureCosmosDB(this IHealthChecksBuilder builder)
+    {
+        builder.AddAzureCosmosDB(
+            clientFactory: provider => provider.GetRequiredService<ICosmosClientProvider>().CosmosClient,
+            optionsFactory: sp =>
+            {
+                IOptions<RepositoryOptions> options = sp.GetRequiredService<IOptions<RepositoryOptions>>();
+                ICosmosItemConfigurationProvider itemConfigProvider = sp.GetRequiredService<ICosmosItemConfigurationProvider>();
+                IEnumerable<string> containers = itemConfigProvider.GetAllItemConfigurations().Select(i => i.ContainerName).Distinct();
+
+                return new AzureCosmosDbHealthCheckOptions
+                {
+                    DatabaseId = options.Value.DatabaseId,
+                    ContainerIds = containers
+                };
+            });
+
+        return builder;
+    }
+}

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -20,7 +20,6 @@ public static class HealthChecksBuilderExtensions
     /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
-    /// <param name="assemblies">The assemblies to scan for <see cref="IItem"/> types. Optional. If <c>null</c> types are discovered autimatically. Providing a assemblies to scan may reduce start up time.</param>
     /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>
     /// <param name="failureStatus">
     /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
@@ -28,13 +27,14 @@ public static class HealthChecksBuilderExtensions
     /// </param>
     /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
     /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <param name="assemblies">The assemblies to scan for <see cref="IItem"/> types. Optional. If <c>null</c> types are discovered autimatically. Providing a assemblies to scan may reduce start up time.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddCosmosRepository(this IHealthChecksBuilder builder,
-        Assembly[]? assemblies = null,
         string? healthCheckName = "azure_cosmosdb",
         HealthStatus? failureStatus = default,
         IEnumerable<string>? tags = default,
-        TimeSpan? timeout = default)
+        TimeSpan? timeout = default,
+        params Assembly[]? assemblies)
     {
         builder.AddAzureCosmosDB(
             clientFactory: provider => provider.GetRequiredService<ICosmosClientProvider>().CosmosClient,

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
@@ -38,6 +38,7 @@
         <RepositoryUrl>https://github.com/IEvangelist/azure-cosmos-dotnet-repository</RepositoryUrl>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <RepositoryType>git</RepositoryType>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
@@ -49,7 +49,6 @@
         <PackageReference Include="Scrutor" />
         <PackageReference Include="AspNetCore.HealthChecks.CosmosDb"  />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"  />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <Company>Microsoft Corporation</Company>
         <Product>IEvangelist Azure Cosmos Repository</Product>
-        <TargetFrameworks>$(DefaultTargetFrameworks);$(CompatibilityTargetFrameworks)</TargetFrameworks>
+        <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
         <Description>This client library enables client applications to connect to Azure Cosmos via a repository pattern around the official Azure Cosmos .NET SDK. Azure Cosmos is a globally distributed, multi-model database service. For more information, refer to http://azure.microsoft.com/services/cosmos-db/. </Description>
         <Copyright>Copyright © IEvangelist. All rights reserved. Licensed under the MIT License.</Copyright>
         <NeutralLanguage>en-US</NeutralLanguage>
@@ -39,26 +38,23 @@
         <RepositoryType>git</RepositoryType>
         <Nullable>enable</Nullable>
     </PropertyGroup>
-
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="MinVer">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Scrutor" />
         <PackageReference Include="AspNetCore.HealthChecks.CosmosDb"  />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks"  />
     </ItemGroup>
-
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Microsoft.Azure.CosmosRepository\Microsoft.Azure.CosmosRepository.csproj" />
     </ItemGroup>
-    
     <ItemGroup>
         <InternalsVisibleTo Include="Microsoft.Azure.CosmosRepository.AspNetCoreTests" />
     </ItemGroup>
-
     <ItemGroup>
         <None Include="..\..\LICENSE">
             <Pack>True</Pack>
@@ -66,5 +62,4 @@
         </None>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
-
 </Project>

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Microsoft.Azure.CosmosRepository.AspNetCore.csproj
@@ -41,6 +41,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="7.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="7.0.14" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
         <PackageReference Include="MinVer" Version="4.3.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ServiceCollectionExtensions.cs
@@ -14,12 +14,12 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="services">The service collection to add services to.</param>
     /// <param name="setupAction">An action to configure the repository options</param>
-    /// <param name="additionSetupAction">An action to configure the <see cref="CosmosClientOptions"/></param>
+    /// <param name="additionalSetupAction">An action to configure the <see cref="CosmosClientOptions"/></param>
     /// <returns>The same service collection that was provided, with the required cosmos services.</returns>
     public static IServiceCollection AddCosmosRepository(
         this IServiceCollection services,
         Action<RepositoryOptions>? setupAction = default,
-        Action<CosmosClientOptions>? additionSetupAction = default)
+        Action<CosmosClientOptions>? additionalSetupAction = default)
     {
         if (services is null)
         {
@@ -34,7 +34,7 @@ public static class ServiceCollectionExtensions
 
         services.AddLogging()
             .AddHttpClient()
-            .AddSingleton(new CosmosClientOptionsManipulator(additionSetupAction))
+            .AddSingleton(new CosmosClientOptionsManipulator(additionalSetupAction))
             .AddSingleton<ICosmosClientOptionsProvider, DefaultCosmosClientOptionsProvider>()
             .AddSingleton<ICosmosClientProvider, DefaultCosmosClientProvider>()
             .AddSingleton(typeof(ICosmosContainerProvider<>), typeof(DefaultCosmosContainerProvider<>))

--- a/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosClientProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosClientProvider.cs
@@ -9,6 +9,8 @@ class DefaultCosmosClientProvider : ICosmosClientProvider, IDisposable
     readonly CosmosClientOptions _cosmosClientOptions;
     readonly RepositoryOptions _options;
 
+    public CosmosClient CosmosClient => _lazyCosmosClient.Value;
+
     private DefaultCosmosClientProvider(
         CosmosClientOptions cosmosClientOptions,
         IOptions<RepositoryOptions> options)

--- a/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
@@ -20,7 +20,7 @@ class DefaultCosmosItemConfigurationProvider(
     public ItemConfiguration GetItemConfiguration(Type itemType) =>
         _itemOptionsMap.GetOrAdd(itemType, AddOptions(itemType));
 
-    public List<ItemConfiguration> GetAllItemConfigurations(Assembly[]? assemblies = null)
+    public List<ItemConfiguration> GetAllItemConfigurations(params Assembly[]? assemblies)
     {
         IEnumerable<Type> itemTypes = (assemblies ?? AppDomain.CurrentDomain.GetAssemblies())
             .SelectMany(s => s.GetTypes())

--- a/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
@@ -20,11 +20,11 @@ class DefaultCosmosItemConfigurationProvider(
     public ItemConfiguration GetItemConfiguration(Type itemType) =>
         _itemOptionsMap.GetOrAdd(itemType, AddOptions(itemType));
 
-    public List<ItemConfiguration> GetAllItemConfigurations()
+    public List<ItemConfiguration> GetAllItemConfigurations(Assembly[]? assemblies = null)
     {
-        IEnumerable<Type> itemTypes = AppDomain.CurrentDomain.GetAssemblies()
+        IEnumerable<Type> itemTypes = (assemblies ?? AppDomain.CurrentDomain.GetAssemblies())
             .SelectMany(s => s.GetTypes())
-            .Where(p => typeof(IItem).IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract);
+            .Where(p => typeof(IItem).IsAssignableFrom(p) && p is {IsInterface: false, IsAbstract: false});
 
         foreach (Type itemType in itemTypes)
         {

--- a/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosItemConfigurationProvider.cs
@@ -20,6 +20,19 @@ class DefaultCosmosItemConfigurationProvider(
     public ItemConfiguration GetItemConfiguration(Type itemType) =>
         _itemOptionsMap.GetOrAdd(itemType, AddOptions(itemType));
 
+    public List<ItemConfiguration> GetAllItemConfigurations()
+    {
+        IEnumerable<Type> itemTypes = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(s => s.GetTypes())
+            .Where(p => typeof(IItem).IsAssignableFrom(p) && !p.IsInterface && !p.IsAbstract);
+
+        foreach (Type itemType in itemTypes)
+        {
+            _itemOptionsMap.GetOrAdd(itemType, AddOptions(itemType));
+        }
+
+        return _itemOptionsMap.Select(i => i.Value).ToList();
+    }
 
     private ItemConfiguration AddOptions(Type itemType)
     {

--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosClientProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosClientProvider.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Azure.CosmosRepository.Providers;
 /// an instance to the configured <see cref="CosmosClient"/> object,
 /// which is shared.
 /// </summary>
-interface ICosmosClientProvider
+internal interface ICosmosClientProvider
 {
     Task<T> UseClientAsync<T>(Func<CosmosClient, Task<T>> consume);
+
+    CosmosClient CosmosClient { get; }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
@@ -12,5 +12,5 @@ internal interface ICosmosItemConfigurationProvider
 
     ItemConfiguration GetItemConfiguration(Type itemType);
 
-    List<ItemConfiguration> GetAllItemConfigurations(Assembly[]? assemblies = null);
+    List<ItemConfiguration> GetAllItemConfigurations(params Assembly[]? assemblies);
 }

--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
@@ -6,9 +6,11 @@ namespace Microsoft.Azure.CosmosRepository.Providers;
 /// <summary>
 /// Holds all of the configuration information for an item.
 /// </summary>
-interface ICosmosItemConfigurationProvider
+internal interface ICosmosItemConfigurationProvider
 {
     ItemConfiguration GetItemConfiguration<TItem>() where TItem : IItem;
 
     ItemConfiguration GetItemConfiguration(Type itemType);
+
+    List<ItemConfiguration> GetAllItemConfigurations();
 }

--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosItemConfigurationProvider.cs
@@ -12,5 +12,5 @@ internal interface ICosmosItemConfigurationProvider
 
     ItemConfiguration GetItemConfiguration(Type itemType);
 
-    List<ItemConfiguration> GetAllItemConfigurations();
+    List<ItemConfiguration> GetAllItemConfigurations(Assembly[]? assemblies = null);
 }

--- a/src/Microsoft.Azure.CosmosRepository/Visibility.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Visibility.cs
@@ -3,3 +3,4 @@
 
 
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.CosmosRepository.AspNetCore")]

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Providers/DefaultCosmosItemConfigurationProviderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Providers/DefaultCosmosItemConfigurationProviderTests.cs
@@ -16,6 +16,17 @@ public class DefaultCosmosItemConfigurationProviderTests
     readonly Mock<ICosmosThroughputProvider> _throughputProvider = new();
     readonly Mock<ICosmosStrictTypeCheckingProvider> _strictTypeCheckingProvider = new();
 
+    public DefaultCosmosItemConfigurationProviderTests()
+    {
+        _containerNameProvider = new Mock<ICosmosContainerNameProvider>();
+        _partitionKeyPathProvider = new Mock<ICosmosPartitionKeyPathProvider>();
+        _uniqueKeyPolicyProvider = new Mock<ICosmosUniqueKeyPolicyProvider>();
+        _defaultTimeToLiveProvider = new Mock<ICosmosContainerDefaultTimeToLiveProvider>();
+        _syncContainerPropertiesProvider = new Mock<ICosmosContainerSyncContainerPropertiesProvider>();
+        _throughputProvider = new Mock<ICosmosThroughputProvider>();
+        _strictTypeCheckingProvider = new Mock<ICosmosStrictTypeCheckingProvider>();
+    }
+
     [Fact]
     public void GetOptionsAlwaysGetOptionsForItem()
     {

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Stubs/TestCosmosClientProvider.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Stubs/TestCosmosClientProvider.cs
@@ -12,4 +12,6 @@ internal class TestCosmosClientProvider : ICosmosClientProvider
 
     public Task<T> UseClientAsync<T>(Func<CosmosClient, Task<T>> consume)
         => consume(_cosmosClient) ?? throw new ArgumentNullException(nameof(consume));
+
+    public CosmosClient CosmosClient => _cosmosClient;
 }


### PR DESCRIPTION
Adds functionality discussed in #366.

Closes #366 

Adds support for [AspNet Core Health Checks](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) using the [HealthChecks.CosmosDb](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.CosmosDb/README.md) package.

## Setup

To configure Cosmos DB health checks:  

```csharp
services.AddHealthChecks().AddCosmosRepository();
```

By default, this will scan all of the assemblies in your solution to locate the container names for each of your `IItem` types.  To refine this, and potentially reduce startup times, pass in the Assemblies containing your `IItem` types:

```csharp
services.AddHealthChecks().AddCosmosRepository(assemblies: typeof(ExampleItem).Assembly);
```

The Cosmos Repository Health package supports all of the existing functionality of Health Checks, such as failureStatus and tags, see the [Microsoft Documentation](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) for configuration details.