### PR TITLE
add property to set 'WithStartTime' on change feed

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/ChangeFeed/ChangeFeedOptions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/ChangeFeed/ChangeFeedOptions.cs
@@ -35,8 +35,31 @@ public class ChangeFeedOptions
     /// </summary>
     public string ProcessorName { get; set; } = "cosmos-repository-pattern-processor";
 
+    private DateTime? _startTime;
+
+    /// <summary>
+    /// Sets the time (exclusive) to start looking for changes after.
+    /// </summary>
+    /// <remarks>
+    /// This is only used when:
+    /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
+    /// (2) StartContinuation is not specified.
+    /// If this is specified, StartFromBeginning is ignored.
+    /// </remarks>
+    public DateTime? StartTime
+    {
+        get => _startTime;
+        set
+        {
+            if (value.HasValue && value.Value.Kind != DateTimeKind.Utc)
+                throw new ArgumentOutOfRangeException(nameof(value),"StartTime must be Utc");
+            _startTime = value;
+        }
+    }
+
     internal bool IsTheSameAs(ChangeFeedOptions? options) =>
         options?.InstanceName == InstanceName &&
         options?.PollInterval == PollInterval &&
-        options?.ProcessorName == ProcessorName;
+        options?.ProcessorName == ProcessorName &&
+        options?.StartTime == StartTime;
 }

--- a/src/Microsoft.Azure.CosmosRepository/ChangeFeed/DefaultConatinerChangeFeedProcessor.cs
+++ b/src/Microsoft.Azure.CosmosRepository/ChangeFeed/DefaultConatinerChangeFeedProcessor.cs
@@ -49,6 +49,10 @@ internal class DefaultContainerChangeFeedProcessor : IContainerChangeFeedProcess
             builder.WithPollInterval(_changeFeedOptions.PollInterval.Value);
         }
 
+        if (_changeFeedOptions.StartTime.HasValue)
+        {
+            builder.WithStartTime(_changeFeedOptions.StartTime.Value);
+        }
         _processor = builder.Build();
 
         _logger.LogInformation("Starting change feed processor for container {ContainerName}", itemContainer.Id);

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/ChangeFeed/ChangeFeedOptionsTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/ChangeFeed/ChangeFeedOptionsTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.CosmosRepositoryTests.ChangeFeed;
+
+public class ChangeFeedOptionsTests
+{
+    [Fact]
+    public void StarTime_Utc_SetsValue()
+    {
+        //Arrange
+        var startTime = new DateTime(2000, 1, 1, 0, 0,0, DateTimeKind.Utc);
+
+        //Act
+        var actual = new ChangeFeedOptions(typeof(object)) { StartTime = startTime };
+
+        //Assert
+        Assert.Equal(startTime, actual.StartTime);
+    }
+
+    [Fact]
+    public void StartTime_NotUtc_Throws()
+    {
+        //Arrange
+        var startTime = new DateTime(2000, 1, 1);
+
+        //Act
+        //Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ChangeFeedOptions(typeof(object)) { StartTime = startTime });
+    }
+
+    [Fact]
+    public void StartTime_Null_SetsValue()
+    {
+        //Arrange
+        //Act
+        var actual = new ChangeFeedOptions(typeof(object)) {StartTime = null};
+
+        //Assert
+        Assert.Null(actual.StartTime);
+    }
+}


### PR DESCRIPTION
Adds an option on `ChangeFeedOptions` used to set `ChangeFeedProcessorBuilder.WithStartTime`