### PR TITLE
Access to CosmosClient creation pull request (#398)

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosClientProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosClientProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers;
 /// an instance to the configured <see cref="CosmosClient"/> object,
 /// which is shared.
 /// </summary>
-internal interface ICosmosClientProvider
+public interface ICosmosClientProvider
 {
     Task<T> UseClientAsync<T>(Func<CosmosClient, Task<T>> consume);
 


### PR DESCRIPTION
Made ICosmosClientProvider public so that the implementations to make the library more extensible, as per my logged issue.

https://github.com/IEvangelist/azure-cosmos-dotnet-repository/issues/398