### PR TITLE
feat: Extend HealthChecks to allow AzureCosmosDbHealthCheckOptions t…

### DIFF
--- a/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
+++ b/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
@@ -19,6 +19,22 @@ By default, this will scan all of the assemblies in your solution to locate the 
 services.AddHealthChecks().AddCosmosRepository(assemblies: typeof(ExampleItem).Assembly);
 ```
 
+Alternatively, use the override to provide your own `AzureCosmosDbHealthCheckOptions` and configure the Containers to check:
+
+```csharp
+services.AddHealthChecks().AddCosmosRepository(optionsFactory: sp => new AzureCosmosDbHealthCheckOptions
+{
+    DatabaseId = "my-database",
+    ContainerIds = new[] { "Container1", "Container2" }
+});
+```
+
+Use `optionsFactory: null` to retain the default behaviour of the [HealthChecks.CosmosDb](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/master/src/HealthChecks.CosmosDb/README.md) package, and only call `CosmosClient.ReadAccountAsync()`.
+
+```csharp
+services.AddHealthChecks().AddCosmosRepository(optionsFactory: null);
+```
+
 The Cosmos Repository Health package supports all of the existing functionality of Health Checks, such as failureStatus and tags, see the [Microsoft Documentation](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks) for configuration details.
 
 Don't forget to map the health endpoint with:

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -55,4 +55,32 @@ public static class HealthChecksBuilderExtensions
 
         return builder;
     }
+
+    /// <summary>
+    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
+    /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <param name="optionsFactory">The `AzureCosmosDbHealthCheckOptions` to use. Optional. If <c>null</c>, the health check just calls CosmosClient.ReadAccountAsync.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddCosmosRepository(this IHealthChecksBuilder builder,
+        string? healthCheckName = "azure_cosmosdb",
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default,
+        Func<IServiceProvider, AzureCosmosDbHealthCheckOptions>? optionsFactory = default
+    )
+    {
+        builder.AddAzureCosmosDB(
+            clientFactory: provider => provider.GetRequiredService<ICosmosClientProvider>().CosmosClient,
+            optionsFactory: optionsFactory, healthCheckName, failureStatus, tags, timeout);
+
+        return builder;
+    }
 }

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -57,7 +57,7 @@ public static class HealthChecksBuilderExtensions
     }
 
     /// <summary>
-    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>. Use this overload to configure <paramref name="AzureCosmosDbHealthCheckOptions"/> to customise which containers to check.
+    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>. Use this overload to configure <see cref="AzureCosmosDbHealthCheckOptions"/> to customise which containers to check.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
     /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/HealthChecksBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
 public static class HealthChecksBuilderExtensions
 {
     /// <summary>
-    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>.
+    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/> Use this overload to automatically scan assemblies for configured containerIds.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
     /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>
@@ -57,7 +57,7 @@ public static class HealthChecksBuilderExtensions
     }
 
     /// <summary>
-    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>.
+    /// Add a health check for Azure Cosmos DB by registering <see cref="AzureCosmosDbHealthCheck"/> for given <paramref name="builder"/>. Use this overload to configure <paramref name="AzureCosmosDbHealthCheckOptions"/> to customise which containers to check.
     /// </summary>
     /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add <see cref="HealthCheckRegistration"/> to.</param>
     /// <param name="healthCheckName">The health check name. Optional. If <c>null</c> the name 'azure_cosmosdb' will be used.</param>
@@ -67,7 +67,7 @@ public static class HealthChecksBuilderExtensions
     /// </param>
     /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
     /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
-    /// <param name="optionsFactory">The `AzureCosmosDbHealthCheckOptions` to use. Optional. If <c>null</c>, the health check just calls CosmosClient.ReadAccountAsync.</param>
+    /// <param name="optionsFactory">The `AzureCosmosDbHealthCheckOptions` to use. Optional. If <c>null</c>, the health check only calls CosmosClient.ReadAccountAsync.</param>
     /// <returns>The specified <paramref name="builder"/>.</returns>
     public static IHealthChecksBuilder AddCosmosRepository(this IHealthChecksBuilder builder,
         string? healthCheckName = "azure_cosmosdb",


### PR DESCRIPTION
Closes #417 

Adds an overload to the `HealthChecksBuilderExtensions` to allow `AzureCosmosDbHealthCheckOptions` to be provided and bypass assembly scanning to look for `IItem` container names.