### PR TITLE
Follow up on Issue 398 : I'm attempting to use the library in a Multi Tenant scenario

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Options/RepositoryOptions.cs
@@ -22,7 +22,7 @@ public class RepositoryOptions
     /// <summary>
     /// Gets or sets the cosmos connection string. Primary or secondary connection strings are valid.
     /// </summary>
-    public string? CosmosConnectionString { get; set; }
+    public virtual string? CosmosConnectionString { get; set; }
 
     /// <summary>
     /// Gets or sets the cosmos account endpoint URI. This can be retrieved from the Overview section of the Azure Portal.
@@ -39,7 +39,7 @@ public class RepositoryOptions
     /// <remarks>
     /// Defaults to "database", unless otherwise specified.
     /// </remarks>
-    public string DatabaseId { get; set; } = "database";
+    public virtual string DatabaseId { get; set; } = "database";
 
     /// <summary>
     /// Gets or sets the name identifier for the cosmos container that corresponds to the <see cref="DatabaseId"/>.
@@ -47,7 +47,7 @@ public class RepositoryOptions
     /// <remarks>
     /// Defaults to "container", unless otherwise specified.
     /// </remarks>
-    public string ContainerId { get; set; } = "container";
+    public virtual string ContainerId { get; set; } = "container";
 
     /// <summary>
     /// Gets or sets whether to optimize bandwidth.

--- a/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosContainerProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/ICosmosContainerProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.CosmosRepository.Providers;
 /// The cosmos container provider exposes a means of providing
 /// an instance to the configured <see cref="Container"/> object.
 /// </summary>
-interface ICosmosContainerProvider<TItem> where TItem : IItem
+public interface ICosmosContainerProvider<TItem> where TItem : IItem
 {
     /// <summary>
     /// Asynchronously gets the configured <see cref="Container"/> instance that corresponds to the


### PR DESCRIPTION
 where each tenant connects to their own specific Cosmos DB

Along with the previous change I did to make ICosmosClientProvider public (https://github.com/IEvangelist/azure-cosmos-dotnet-repository/issues/398)

* ICosmosContainerProvider  - made this public, the default implementation caches containers, I needed a custom implementation to cache these per Tenant

* RepositoryOptions
- I made `DatabaseId`, `ContainerId` and `ConnectionString` virtual, again in my implementation I need these to be tenant specific, making these virtual allows me replace this with a multi-tenant version of RepositoryOptions