### PR TITLE
Feature/support continuation token limit property

### DIFF
--- a/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Read.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Read.cs
@@ -75,9 +75,9 @@ internal partial class DefaultEventStore<TEventItem>
         do
         {
             IPage<TEventItem> page = await readOnlyRepository.PageAsync(
-                predicate: expression,
-                pageSize: chunkSize,
-                continuationToken: token,
+                expression,
+                chunkSize,
+                token,
                 cancellationToken: cancellationToken);
 
             token = page.Continuation;

--- a/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Read.cs
+++ b/src/Microsoft.Azure.CosmosEventSourcing/Stores/DefaultEventStore.Read.cs
@@ -75,9 +75,9 @@ internal partial class DefaultEventStore<TEventItem>
         do
         {
             IPage<TEventItem> page = await readOnlyRepository.PageAsync(
-                expression,
-                chunkSize,
-                token,
+                predicate: expression,
+                pageSize: chunkSize,
+                continuationToken: token,
                 cancellationToken: cancellationToken);
 
             token = page.Continuation;

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Paging.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Paging.cs
@@ -3,6 +3,10 @@
 
 
 // ReSharper disable once CheckNamespace
+using System.Threading;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
 namespace Microsoft.Azure.CosmosRepository;
 
 internal sealed partial class DefaultRepository<TItem>
@@ -14,18 +18,35 @@ internal sealed partial class DefaultRepository<TItem>
         string? continuationToken = null,
         bool returnTotal = false,
         CancellationToken cancellationToken = default)
+        => await PageAsync(
+            new QueryRequestOptions() { MaxItemCount = pageSize },
+            predicate,
+            pageSize,
+            continuationToken,
+            returnTotal,
+            cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask<IPage<TItem>> PageAsync(
+        QueryRequestOptions requestOptions,
+        Expression<Func<TItem, bool>>? predicate = null,
+        int pageSize = 25,
+        string? continuationToken = null,
+        bool returnTotal = false,
+        CancellationToken cancellationToken = default)
     {
         Container container = await containerProvider.GetContainerAsync()
             .ConfigureAwait(false);
 
-        QueryRequestOptions options = new()
+        // make sure that if the user hasn't said the value already we take it from the pageSize parameter
+        if (requestOptions.MaxItemCount is null)
         {
-            MaxItemCount = pageSize
-        };
+            requestOptions.MaxItemCount = pageSize;
+        }
 
         IQueryable<TItem> query = container
             .GetItemLinqQueryable<TItem>(
-                requestOptions: options,
+                requestOptions: requestOptions,
                 continuationToken: continuationToken,
                 linqSerializerOptions: optionsMonitor.CurrentValue.SerializationOptions)
             .Where(repositoryExpressionProvider.Build(
@@ -61,13 +82,30 @@ internal sealed partial class DefaultRepository<TItem>
         int pageSize = 25,
         bool returnTotal = false,
         CancellationToken cancellationToken = default)
+    => await PageAsync(
+            requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize },
+            predicate: predicate,
+            pageNumber: pageNumber,
+            pageSize: pageSize,
+            returnTotal: returnTotal,
+            cancellationToken: cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask<IPageQueryResult<TItem>> PageAsync(
+        QueryRequestOptions requestOptions,
+        Expression<Func<TItem, bool>>? predicate = null,
+        int pageNumber = 1,
+        int pageSize = 25,
+        bool returnTotal = false,
+        CancellationToken cancellationToken = default)
     {
         Container container = await containerProvider.GetContainerAsync()
             .ConfigureAwait(false);
 
         IQueryable<TItem> query = container
             .GetItemLinqQueryable<TItem>(
-                linqSerializerOptions: optionsMonitor.CurrentValue.SerializationOptions)
+                linqSerializerOptions: optionsMonitor.CurrentValue.SerializationOptions,
+                requestOptions: requestOptions)
             .Where(repositoryExpressionProvider
                 .Build(predicate ?? repositoryExpressionProvider.Default<TItem>()));
 

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Specs.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.Specs.cs
@@ -12,21 +12,26 @@ internal sealed partial class DefaultRepository<TItem>
         ISpecification<TItem, TResult> specification,
         CancellationToken cancellationToken = default)
         where TResult : IQueryResult<TItem>
+        => await QueryAsync(specification, new QueryRequestOptions(), cancellationToken);
+
+    /// <inheritdoc/>
+    public async ValueTask<TResult> QueryAsync<TResult>(
+        ISpecification<TItem, TResult> specification,
+        QueryRequestOptions requestOptions,
+        CancellationToken cancellationToken = default) where TResult : IQueryResult<TItem>
     {
         Container container = await containerProvider.GetContainerAsync()
             .ConfigureAwait(false);
 
-        QueryRequestOptions options = new();
-
         if (specification.UseContinuationToken)
         {
-            options.MaxItemCount = specification.PageSize;
+            requestOptions.MaxItemCount = specification.PageSize;
         }
 
         IQueryable<TItem> query = container
             .GetItemLinqQueryable<TItem>(
-                requestOptions: options,
-                continuationToken: specification.ContinuationToken, 
+                requestOptions: requestOptions,
+                continuationToken: specification.ContinuationToken,
                 linqSerializerOptions: optionsMonitor.CurrentValue.SerializationOptions)
             .Where(repositoryExpressionProvider.Default<TItem>());
 

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.cs
@@ -64,19 +64,4 @@ internal sealed partial class DefaultRepository<TItem>(
 
         return (results, charge, continuationToken);
     }
-
-    public ValueTask<IPage<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageSize = 25, string? continuationToken = null, bool returnTotal = false, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask<TResult> QueryAsync<TResult>(ISpecification<TItem, TResult> specification, QueryRequestOptions requestOptions, CancellationToken cancellationToken = default) where TResult : IQueryResult<TItem>
-    {
-        throw new NotImplementedException();
-    }
-
-    public ValueTask<IPageQueryResult<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageNumber = 1, int pageSize = 25, bool returnTotal = false, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/DefaultRepository.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 // ReSharper disable once CheckNamespace
+
+
 namespace Microsoft.Azure.CosmosRepository;
 
 /// <inheritdoc/>
@@ -61,5 +63,20 @@ internal sealed partial class DefaultRepository<TItem>(
         }
 
         return (results, charge, continuationToken);
+    }
+
+    public ValueTask<IPage<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageSize = 25, string? continuationToken = null, bool returnTotal = false, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<TResult> QueryAsync<TResult>(ISpecification<TItem, TResult> specification, QueryRequestOptions requestOptions, CancellationToken cancellationToken = default) where TResult : IQueryResult<TItem>
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<IPageQueryResult<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageNumber = 1, int pageSize = 25, bool returnTotal = false, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IReadOnlyRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IReadOnlyRepository.cs
@@ -185,6 +185,26 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Offers a load more paging implementation for infinite scroll scenarios.
+    /// Allows for efficient paging making use of cosmos DBs continuation tokens, making this implementation cost effective.
+    /// </summary>
+    /// <param name="requestOptions">An <see cref="QueryRequestOptions"/> to specify query options for Cosmos SDK</param>
+    /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
+    /// <param name="pageSize">The size of the page to return from cosmos db.</param>
+    /// <param name="continuationToken">The token returned from a previous query, if null starts at the beginning of the data</param>
+    /// <param name="returnTotal">Specifies whether or not to return the total number of items that matched the query. This defaults to false as it can be a very expensive operation.</param>
+    /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
+    /// <returns>An <see cref="IPage{T}"/> of <see cref="IItem"/>s</returns>
+    /// <remarks>This method makes use of cosmos dbs continuation tokens for efficient, cost effective paging utilising low RUs</remarks>
+    ValueTask<IPage<TItem>> PageAsync(
+        QueryRequestOptions requestOptions,
+        Expression<Func<TItem, bool>>? predicate = null,
+        int pageSize = 25,
+        string? continuationToken = null,
+        bool returnTotal = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get items based on a specification.
     /// The specification is used to define which filters are used, the order of the search results and how they are paged.
     /// Depending on how results are paged derive specification implementations from different classes:
@@ -203,6 +223,26 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
         where TResult : IQueryResult<TItem>;
 
     /// <summary>
+    /// Get items based on a specification.
+    /// The specification is used to define which filters are used, the order of the search results and how they are paged.
+    /// Depending on how results are paged derive specification implementations from different classes:
+    /// For non paged results derive <see cref="DefaultSpecification{TItem}"/>
+    /// For continuation token derive <see cref="ContinuationTokenSpecification{T}"/>
+    /// For page number results derive <see cref="OffsetByPageNumberSpecification{T}"/>
+    /// </summary>
+    /// <typeparam name="TResult">Decides which paging information is retrieved. Use <see cref="ContinuationTokenSpecification{T}"/></typeparam>
+    /// <param name="specification">A specification used to filtering, ordering and paging. A <see cref="ISpecification{T, TResult}"/></param>
+    /// <param name="requestOptions">An <see cref="QueryRequestOptions"/> to specify query options for Cosmos SDK</param>
+    /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
+    /// <returns>The selected <typeparamref name="TResult"/> implementation that implements <see cref="IQueryResult{T}"/> of <see cref="IItem"/></returns>
+    /// <remarks>This method makes use of cosmos dbs continuation tokens for efficient, cost effective paging utilising low RUs</remarks>
+    ValueTask<TResult> QueryAsync<TResult>(
+        ISpecification<TItem, TResult> specification,
+        QueryRequestOptions requestOptions,
+        CancellationToken cancellationToken = default)
+        where TResult : IQueryResult<TItem>;
+
+    /// <summary>
     /// Offers a load more paging implementation for infinite scroll scenarios.
     /// Allows for efficient paging making use of cosmos DBs continuation tokens, making this implementation cost effective.
     /// </summary>
@@ -214,6 +254,26 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
     /// <returns>An <see cref="IPageQueryResult{T}"/> of <see cref="IItem"/>s</returns>
     /// <remarks>This method makes use of Cosmos DB's continuation tokens for efficient, cost effective paging utilizing low RUs</remarks>
     ValueTask<IPageQueryResult<TItem>> PageAsync(
+        Expression<Func<TItem, bool>>? predicate = null,
+        int pageNumber = 1,
+        int pageSize = 25,
+        bool returnTotal = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Offers a load more paging implementation for infinite scroll scenarios.
+    /// Allows for efficient paging making use of cosmos DBs continuation tokens, making this implementation cost effective.
+    /// </summary>
+    /// <param name="requestOptions">An <see cref="QueryRequestOptions"/> to specify query options for Cosmos SDK</param>
+    /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
+    /// <param name="pageNumber">The page number to return from cosmos db.</param>
+    /// <param name="pageSize">The size of the page to return from cosmos db.</param>
+    /// <param name="returnTotal">Specifies whether or not to return the total number of items that matched the query. This defaults to false as it can be a very expensive operation.</param>
+    /// <param name="cancellationToken">The cancellation token to use when making asynchronous operations.</param>
+    /// <returns>An <see cref="IPageQueryResult{T}"/> of <see cref="IItem"/>s</returns>
+    /// <remarks>This method makes use of Cosmos DB's continuation tokens for efficient, cost effective paging utilizing low RUs</remarks>
+    ValueTask<IPageQueryResult<TItem>> PageAsync(
+        QueryRequestOptions requestOptions,
         Expression<Func<TItem, bool>>? predicate = null,
         int pageNumber = 1,
         int pageSize = 25,
@@ -259,6 +319,50 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
                 }
 
                 collected ++;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wraps the existing paging support to return an <see cref="IAsyncEnumerable{T}"/>
+    /// where <c>T</c> is <typeparamref name="TItem"/>.
+    /// </summary>
+    /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
+    /// <param name="limit">The limit of how many items to yield. Defaults to <c>1,000</c>.</param>
+    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> used to </param>
+    /// <returns>An <see cref="IAsyncEnumerable{T}"/> where <c>T</c> is <typeparamref name="TItem"/>.</returns>
+    /// <remarks>This method makes use of Cosmos DB's continuation tokens for efficient, cost effective paging utilizing low RUs</remarks>
+    async IAsyncEnumerable<TItem> PageAsync(
+        QueryRequestOptions requestOptions,
+        Expression<Func<TItem, bool>>? predicate = null,
+        int limit = 1_000,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var collected = 0;
+        var currentPage = 0;
+        var hasMoreResults = true;
+
+        while (hasMoreResults && collected < limit
+            && cancellationToken.IsCancellationRequested is false)
+        {
+            IPageQueryResult<TItem> page = await PageAsync(
+                requestOptions,
+                predicate,
+                pageNumber: ++currentPage,
+                25,
+                returnTotal: false,
+                cancellationToken);
+
+            hasMoreResults = page.HasNextPage.GetValueOrDefault();
+
+            foreach (TItem item in page.Items)
+            {
+                if (collected < limit)
+                {
+                    yield return item;
+                }
+
+                collected++;
             }
         }
     }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.cs
@@ -3,6 +3,7 @@
 
 
 // ReSharper disable once CheckNamespace
+
 namespace Microsoft.Azure.CosmosRepository;
 
 /// <inheritdoc/>
@@ -22,4 +23,19 @@ internal partial class InMemoryRepository<TItem> : IRepository<TItem>
 
     private void NotFound() => throw new CosmosException(string.Empty, HttpStatusCode.NotFound, 0, string.Empty, 0);
     private void Conflict() => throw new CosmosException(string.Empty, HttpStatusCode.Conflict, 0, string.Empty, 0);
+
+    public ValueTask<IPage<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageSize = 25, string? continuationToken = null, bool returnTotal = false, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<TResult> QueryAsync<TResult>(ISpecification<TItem, TResult> specification, QueryRequestOptions requestOptions, CancellationToken cancellationToken = default) where TResult : IQueryResult<TItem>
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<IPageQueryResult<TItem>> PageAsync(QueryRequestOptions requestOptions, Expression<Func<TItem, bool>>? predicate = null, int pageNumber = 1, int pageSize = 25, bool returnTotal = false, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
 }


### PR DESCRIPTION
This PR will add support for the [Cosmos SDK API QueryOptionsClass](https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.queryrequestoptions?view=azure-dotnet) which enables consumers of these APIs to provide their own settings for the `CosmosClient`.

This PR aims to solve: #432

@IEvangelist I have made an initial PR here (no tests or so yet) in order to make sure I am on the right track before spending more time on this. I have two questions that will need discussion:

- It might be confusing for users to provide both the query options _AND_ page size, as they might enter the same information twice (if they provided MaxItemCount in query options to begin with). I do not know what your thought is about this.
- Are you ok with the method overloading (i.e. that I simply call the new method from the existing API), with same logic + a default instance of `QueryOptionsClass`