### PR TITLE
Add full path support for the patch operations

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -22,20 +22,20 @@ internal class PatchOperationBuilder<TItem> : IPatchOperationBuilder<TItem> wher
 
     public IPatchOperationBuilder<TItem> Replace<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value)
     {
-        IEnumerable<PropertyInfo> properties = expression.GetPropertiesInfo();
-        var propertyToReplace = GetPropertyToReplace(properties);
+        IEnumerable<PropertyInfo> propertyInfos = expression.GetPropertyInfos();
+        var propertyToReplace = GetPropertyToReplace(propertyInfos);
 
-        _rawPatchOperations.Add(new InternalPatchOperation(properties.ToArray(), value, PatchOperationType.Replace));
+        _rawPatchOperations.Add(new InternalPatchOperation(propertyInfos.ToArray(), value, PatchOperationType.Replace));
         _patchOperations.Add(PatchOperation.Replace($"/{propertyToReplace}", value));
 
         return this;
     }
 
-    private string GetPropertyToReplace(IEnumerable<PropertyInfo> propertiesInfo)
+    private string GetPropertyToReplace(IEnumerable<PropertyInfo> propertyInfos)
     {
         List<string> propertiesNames = [];
 
-        foreach (PropertyInfo propertyInfo in propertiesInfo)
+        foreach (PropertyInfo propertyInfo in propertyInfos)
         {
             JsonPropertyAttribute[] attributes =
                 propertyInfo.GetCustomAttributes<JsonPropertyAttribute>(true).ToArray();

--- a/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Builders/PatchOperationBuilder.cs
@@ -22,16 +22,19 @@ internal class PatchOperationBuilder<TItem> : IPatchOperationBuilder<TItem> wher
 
     public IPatchOperationBuilder<TItem> Replace<TValue>(Expression<Func<TItem, TValue>> expression, TValue? value)
     {
-        IEnumerable<PropertyInfo> propertyInfos = expression.GetPropertyInfos();
+        IReadOnlyList<PropertyInfo> propertyInfos = expression.GetPropertyInfos();
         var propertyToReplace = GetPropertyToReplace(propertyInfos);
 
-        _rawPatchOperations.Add(new InternalPatchOperation(propertyInfos.ToArray(), value, PatchOperationType.Replace));
+        _rawPatchOperations.Add(new InternalPatchOperation(propertyInfos, value, PatchOperationType.Replace));
         _patchOperations.Add(PatchOperation.Replace($"/{propertyToReplace}", value));
 
         return this;
     }
 
-    private string GetPropertyToReplace(IEnumerable<PropertyInfo> propertyInfos)
+    private string GetPropertyToReplace(MemberInfo propertyInfo) =>
+        GetPropertyToReplace([propertyInfo]);
+
+    private string GetPropertyToReplace(IEnumerable<MemberInfo> propertyInfos)
     {
         List<string> propertiesNames = [];
 

--- a/src/Microsoft.Azure.CosmosRepository/Extensions/ExpressionExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/ExpressionExtensions.cs
@@ -37,11 +37,11 @@ internal static class ExpressionExtensions
         this Expression<Func<T, bool>> first,
         Expression<Func<T, bool>> second) => first.Compose(second, Expression.Or);
 
-    internal static IEnumerable<PropertyInfo> GetPropertiesInfo<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyLambda)
+    internal static IEnumerable<PropertyInfo> GetPropertyInfos<TSource, TProperty>(this Expression<Func<TSource, TProperty>> propertyLambda)
     {
         Type type = typeof(TSource);
 
-        List<PropertyInfo> propertiesInfo = [];
+        List<PropertyInfo> propertyInfos = [];
 
         MemberExpression? member = propertyLambda.Body as MemberExpression;
 
@@ -57,14 +57,14 @@ internal static class ExpressionExtensions
                 throw new ArgumentException($"Expression '{propertyLambda}' refers to a field, not a property.");
             }
 
-            propertiesInfo.Add(propertyInfo);
+            propertyInfos.Add(propertyInfo);
 
             member = member.Expression as MemberExpression;
         }
 
-        propertiesInfo.Reverse(); // The properties are added from the leaf to the root, so we reverse to get them in the correct order.
+        propertyInfos.Reverse(); // The properties are added from the leaf to the root, so we reverse to get them in the correct order.
 
-        PropertyInfo propInfo = propertiesInfo[0];
+        PropertyInfo propInfo = propertyInfos[0];
 
 #pragma warning disable IDE0046 // Convert to conditional expression
         if (propInfo.ReflectedType != null &&
@@ -75,6 +75,6 @@ internal static class ExpressionExtensions
         }
 #pragma warning restore IDE0046 // Convert to conditional expression
 
-        return propertiesInfo;
+        return propertyInfos;
     }
 }

--- a/src/Microsoft.Azure.CosmosRepository/Internals/InternalPatchOperation.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Internals/InternalPatchOperation.cs
@@ -3,10 +3,10 @@
 
 namespace Microsoft.Azure.CosmosRepository.Internals;
 
-internal class InternalPatchOperation(PropertyInfo propertyInfo, object? newValue, PatchOperationType type)
+internal class InternalPatchOperation(IReadOnlyList<PropertyInfo> propertiesInfo, object? newValue, PatchOperationType type)
 {
     public PatchOperationType Type { get; } = type;
-    public PropertyInfo PropertyInfo { get; } = propertyInfo;
+    public IReadOnlyList<PropertyInfo> PropertiesInfo { get; } = propertiesInfo;
 
     public object? NewValue { get; } = newValue;
 }

--- a/src/Microsoft.Azure.CosmosRepository/Internals/InternalPatchOperation.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Internals/InternalPatchOperation.cs
@@ -3,10 +3,11 @@
 
 namespace Microsoft.Azure.CosmosRepository.Internals;
 
-internal class InternalPatchOperation(IReadOnlyList<PropertyInfo> propertiesInfo, object? newValue, PatchOperationType type)
+internal class InternalPatchOperation(IReadOnlyList<PropertyInfo> propertyInfos, object? newValue, PatchOperationType type)
 {
     public PatchOperationType Type { get; } = type;
-    public IReadOnlyList<PropertyInfo> PropertiesInfo { get; } = propertiesInfo;
+
+    public IReadOnlyList<PropertyInfo> PropertyInfos { get; } = propertyInfos;
 
     public object? NewValue { get; } = newValue;
 }

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Update.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Update.cs
@@ -107,23 +107,23 @@ internal partial class InMemoryRepository<TItem>
         foreach (InternalPatchOperation internalPatchOperation in
                  patchOperationBuilder._rawPatchOperations.Where(ipo => ipo.Type is PatchOperationType.Replace))
         {
-            IReadOnlyList<PropertyInfo> propertiesInfo = internalPatchOperation.PropertiesInfo;
+            IReadOnlyList<PropertyInfo> propertyInfos = internalPatchOperation.PropertyInfos;
             object? currentObject = item;
 
-            if (propertiesInfo.Count == 0)
+            if (propertyInfos.Count is 0)
             {
                 continue;
             }
 
-            for (var i = 0; i < propertiesInfo.Count; i++)
+            for (var i = 0; i < propertyInfos.Count; i++)
             {
-                if (i == propertiesInfo.Count - 1)
+                if (i == propertyInfos.Count - 1)
                 {
-                    propertiesInfo[i].SetValue(currentObject, internalPatchOperation.NewValue);
+                    propertyInfos[i].SetValue(currentObject, internalPatchOperation.NewValue);
                     break;
                 }
 
-                currentObject = propertiesInfo[i].GetValue(currentObject);
+                currentObject = propertyInfos[i].GetValue(currentObject);
             }
         }
 

--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Update.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Update.cs
@@ -107,8 +107,24 @@ internal partial class InMemoryRepository<TItem>
         foreach (InternalPatchOperation internalPatchOperation in
                  patchOperationBuilder._rawPatchOperations.Where(ipo => ipo.Type is PatchOperationType.Replace))
         {
-            PropertyInfo property = item!.GetType().GetProperty(internalPatchOperation.PropertyInfo.Name)!;
-            property.SetValue(item, internalPatchOperation.NewValue);
+            IReadOnlyList<PropertyInfo> propertiesInfo = internalPatchOperation.PropertiesInfo;
+            object? currentObject = item;
+
+            if (propertiesInfo.Count == 0)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < propertiesInfo.Count; i++)
+            {
+                if (i == propertiesInfo.Count - 1)
+                {
+                    propertiesInfo[i].SetValue(currentObject, internalPatchOperation.NewValue);
+                    break;
+                }
+
+                currentObject = propertiesInfo[i].GetValue(currentObject);
+            }
         }
 
         ConcurrentDictionary<string, string> items = InMemoryStorage.GetDictionary<TItem>();

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/InMemoryRepositoryTests.cs
@@ -990,6 +990,36 @@ public class InMemoryRepositoryTests
     }
 
     [Fact]
+    public async Task UpdateAsync_PropertiesInNestedObjectToPatch_UpdatesValues()
+    {
+        //Arrange
+        RootObject root = new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            NestedObject = new NestedObject
+            {
+                Property1 = "prop1",
+                Property2 = 55
+            }
+        };
+
+        InMemoryStorage.GetDictionary<RootObject>().TryAddAsJson(root.Id, root);
+
+        //Act
+        await _rootObjectRepository.UpdateAsync(
+            root.Id,
+            builder =>
+                builder.Replace(x => x.NestedObject.Property1, "prop2")
+                    .Replace(x => x.NestedObject.Property2, 2));
+
+        //Assert
+        RootObject deserialisedItem =
+            _rootObjectRepository.DeserializeItem(InMemoryStorage.GetDictionary<RootObject>().First().Value);
+        Assert.Equal("prop2", deserialisedItem.NestedObject.Property1);
+        Assert.Equal(2, deserialisedItem.NestedObject.Property2);
+    }
+
+    [Fact]
     public async Task PageAsync_PredicateThatDoesNotMatch_ReturnsEmptyList()
     {
         //Arrange


### PR DESCRIPTION
I would like to propose a new solution to generate a path for Patch operations.

Currently, when a property is selected using a lambda to create a path for a Patch operation, the last property is selected and only the path is created based on that property. (Example: **x => x.NestedObject.Property1** creates for us path **/property1**).

The proposed solution creates a full path for the Patch operation taking into account all the properties that have been selected in the lambda. (Example: **x => x.NestedObject.Property1** creates for us path **/nestedObject/property1**)