### PR TITLE
Add page size parameter to PageAsync with IAsyncEnumerable

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Repositories/IReadOnlyRepository.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/IReadOnlyRepository.cs
@@ -227,12 +227,14 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
     /// </summary>
     /// <param name="predicate">A filter criteria for the paging operation, if null it will get all <see cref="IItem"/>s</param>
     /// <param name="limit">The limit of how many items to yield. Defaults to <c>1,000</c>.</param>
+    /// <param name="pageSize">The size of the page to return from cosmos db.</param>
     /// <param name="cancellationToken">The optional <see cref="CancellationToken"/> used to </param>
     /// <returns>An <see cref="IAsyncEnumerable{T}"/> where <c>T</c> is <typeparamref name="TItem"/>.</returns>
     /// <remarks>This method makes use of Cosmos DB's continuation tokens for efficient, cost effective paging utilizing low RUs</remarks>
     async IAsyncEnumerable<TItem> PageAsync(
         Expression<Func<TItem, bool>>? predicate = null,
         int limit = 1_000,
+        int pageSize = 25,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var collected = 0;
@@ -245,7 +247,7 @@ public interface IReadOnlyRepository<TItem> where TItem : IItem
             IPageQueryResult<TItem> page = await PageAsync(
                 predicate,
                 pageNumber: ++ currentPage,
-                25,
+                pageSize,
                 returnTotal: false,
                 cancellationToken);
 


### PR DESCRIPTION
I would like to propose adding a parameter for page size to PageAsync which returns IAsyncEnumerable.
The default size will still remain 25 but if someone wanted to change it there would be an option to do so.

I think it would be possible to achieve the same result with #437 but it is not clear when it will be finished.