### PR TITLE
Added check for URI when verifying if emulator connection string

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Extensions/StringExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Extensions/StringExtensions.cs
@@ -18,6 +18,11 @@ internal static class StringExtensions
             return false;
         }
 
+        if (Uri.TryCreate(connectionString, UriKind.Absolute, out var _))
+        {
+            return false;
+        }
+
         var builder = new DbConnectionStringBuilder
         {
             ConnectionString = connectionString


### PR DESCRIPTION
When using AddCosmosRepositoryClient, options and clientOptions successfully process when using a connection string. But when a named connection string that represents the "AccountEndpoint", options' action successfully processes it as an AccountEndpoint that will use DefaultCredential but  IsEmulatorConnectionString throws an exception when creating the DbConnectionStringBuilder