### PR TITLE
Allow continuation token specification in in memory repository

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Specs.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Repositories/InMemoryRepository.Specs.cs
@@ -18,7 +18,7 @@ internal partial class InMemoryRepository<TItem>
         await Task.CompletedTask;
 #endif
 
-        if (specification.UseContinuationToken)
+        if (specification.ContinuationToken is not null)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Reduces the restrictions on the use of continuation token specification in the in memory repository by only throwing a not-implemented exception if a continuation token is populated. 

At present this will throw if continuation tokens are enabled at all, which makes it impossible to use the in memory repository for integration testing if you're making use of the ContinuationTokenSpecification. This change makes this possible, without having to implement continuation token paging in the in memory repository. 

@IEvangelist My team and I are making use of this awesome library but are currently blocked from adding test coverage for our paged endpoints. Please let me know if this change is something you'd be happy with. 