### PR TITLE
Add Eager DB initialisation, and sample app to prove functionality

### DIFF
--- a/docs/cosmos-repo/content/6-miscellaneous/container-initialization/_index.md
+++ b/docs/cosmos-repo/content/6-miscellaneous/container-initialization/_index.md
@@ -1,0 +1,227 @@
+---
+title: "Container Initialization"
+weight: 4
+---
+
+This page explains how and when Cosmos DB containers are created when using the repository pattern.
+
+## Lazy Initialization (Default)
+
+By default, Cosmos DB containers are created **lazily** - they are created on the first repository operation that accesses them.
+
+```csharp
+// Container doesn't exist yet
+var repository = serviceProvider.GetRequiredService<IRepository<Product>>();
+
+// Container is created here on first access
+var product = await repository.CreateAsync(new Product { Name = "Widget" });
+```
+
+### How Lazy Initialization Works
+
+1. Application starts - no containers are created
+2. First repository operation (`CreateAsync`, `GetAsync`, etc.) is called
+3. The `ICosmosContainerService` checks if the container exists
+4. If `IsAutoResourceCreationIfNotExistsEnabled` is `true`, the container is created
+5. The repository operation completes
+
+### Configuration
+
+Lazy initialization is controlled by the `IsAutoResourceCreationIfNotExistsEnabled` option:
+
+```csharp
+builder.Services.AddCosmosRepository(options =>
+{
+    options.IsAutoResourceCreationIfNotExistsEnabled = true; // Default
+});
+```
+
+**When `IsAutoResourceCreationIfNotExistsEnabled` is `true`:**
+- Containers are created automatically on first access
+- Database is created if it doesn't exist
+- Convenient for development and environments where you control the infrastructure
+
+**When `IsAutoResourceCreationIfNotExistsEnabled` is `false`:**
+- Containers must already exist
+- Application throws an exception if a container is missing
+- Recommended for production when using Infrastructure as Code (Terraform, ARM templates, etc.)
+
+### Pros and Cons of Lazy Initialization
+
+✅ **Pros:**
+- Simple - no additional code required
+- Containers only created if actually used
+- Good for development
+
+❌ **Cons:**
+- First request has higher latency (container creation time)
+- Health checks may fail during startup while containers are being created
+- Configuration errors not discovered until runtime
+- Can cause issues with Kubernetes readiness probes
+
+## Eager Initialization
+
+Eager initialization creates containers **at application startup** before any requests are handled.
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCosmosRepository(options =>
+{
+    options.ContainerBuilder.Configure<Product>(c => 
+        c.WithContainer("products").WithPartitionKey("/category"));
+});
+
+var app = builder.Build();
+
+// Eagerly initialize containers before the app starts
+await app.Services.EagerlyInitializeCosmosContainersAsync();
+
+app.Run();
+```
+
+### How Eager Initialization Works
+
+The `EagerlyInitializeCosmosContainersAsync()` method:
+
+1. Checks if `IsAutoResourceCreationIfNotExistsEnabled` is `true` (returns immediately if `false`)
+2. Discovers item types in priority order:
+   - Types explicitly configured via `ContainerBuilder.Configure<TItem>()`
+   - Types from provided assemblies (if assemblies parameter is provided)
+   - Types from all loaded assemblies (as fallback)
+3. Calls `ICosmosContainerService.GetContainerAsync()` for each type
+4. Waits for all containers to be created before returning
+5. Logs detailed information about the initialization process
+
+### When to Use Eager Initialization
+
+✅ **Use when:**
+- Your application uses health checks (Kubernetes, load balancers, etc.)
+- You want consistent performance on all requests (including the first)
+- You want to fail fast during startup if Cosmos DB is misconfigured
+- Running in containerized environments with readiness probes
+- You have a small number of containers
+
+❌ **Don't use when:**
+- `IsAutoResourceCreationIfNotExistsEnabled` is `false` (it does nothing)
+- You have many containers and want faster startup time
+- Containers are created through Infrastructure as Code
+- You're okay with lazy initialization behavior
+
+### Explicit Type Discovery
+
+If you have item types but they're not being discovered automatically, you can pass assemblies explicitly:
+
+```csharp
+await app.Services.EagerlyInitializeCosmosContainersAsync(
+    typeof(Product).Assembly,
+    typeof(Order).Assembly);
+```
+
+However, if you use `ContainerBuilder.Configure<T>()`, types are discovered automatically:
+
+```csharp
+// Product will be discovered automatically - no assembly parameter needed
+builder.Services.AddCosmosRepository(options =>
+{
+    options.ContainerBuilder.Configure<Product>(c => c.WithContainer("products"));
+});
+
+await app.Services.EagerlyInitializeCosmosContainersAsync(); // Discovers Product
+```
+
+## Comparison
+
+| Aspect | Lazy Initialization | Eager Initialization |
+|--------|-------------------|---------------------|
+| **When containers are created** | On first repository access | At application startup |
+| **First request latency** | Higher (includes container creation) | Normal (containers already exist) |
+| **Startup time** | Faster | Slower (waits for containers) |
+| **Configuration** | Default behavior | Requires explicit call |
+| **Health checks** | May fail during initialization | Pass immediately after startup |
+| **Fail-fast behavior** | Errors discovered at runtime | Errors discovered at startup |
+| **Best for** | Development, simple apps | Production with health checks |
+
+## Common Scenarios
+
+### Development Environment
+
+```csharp
+// Simple setup - lazy initialization is fine
+builder.Services.AddCosmosRepository(options =>
+{
+    options.CosmosConnectionString = "AccountEndpoint=https://localhost:8081/...";
+    options.IsAutoResourceCreationIfNotExistsEnabled = true;
+});
+```
+
+### Production with Health Checks
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCosmosRepository(options =>
+{
+    options.IsAutoResourceCreationIfNotExistsEnabled = true;
+    options.ContainerBuilder.Configure<Product>(c => c.WithContainer("products"));
+    options.ContainerBuilder.Configure<Order>(c => c.WithContainer("orders"));
+});
+
+builder.Services.AddHealthChecks().AddCosmosRepository();
+
+var app = builder.Build();
+
+// Ensure containers exist before health checks run
+await app.Services.EagerlyInitializeCosmosContainersAsync();
+
+app.MapHealthChecks("/health");
+app.Run();
+```
+
+### Production with Infrastructure as Code
+
+```csharp
+// Containers created externally (Terraform, ARM templates, etc.)
+builder.Services.AddCosmosRepository(options =>
+{
+    options.IsAutoResourceCreationIfNotExistsEnabled = false; // Containers must exist
+});
+
+// No eager initialization needed - containers already exist
+```
+
+## Logging
+
+Both initialization approaches provide detailed logging:
+
+```
+// Lazy initialization
+[Debug] Container 'products' does not exist. Creating...
+[Information] Successfully created container 'products'
+
+// Eager initialization
+[Information] Eagerly initializing 2 Cosmos DB container(s) for 2 item type(s)
+[Debug] Successfully initialized container 'products' for item type 'Product'
+[Debug] Successfully initialized container 'orders' for item type 'Order'
+[Information] Successfully completed eager initialization of 2 Cosmos DB container(s)
+```
+
+Set logging level to `Debug` to see detailed initialization information:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Microsoft.Azure.CosmosRepository": "Debug"
+    }
+  }
+}
+```
+
+## Best Practices
+
+1. **Use eager initialization with health checks** - Prevents health check failures during container creation
+2. **Configure types explicitly** - Use `ContainerBuilder.Configure<T>()` for automatic discovery
+3. **Set `IsAutoResourceCreationIfNotExistsEnabled = false` in production** - When using Infrastructure as Code
+4. **Monitor startup logs** - Verify containers are created successfully
+5. **Use appropriate timeouts** - For Kubernetes startup probes when using eager initialization

--- a/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
+++ b/docs/cosmos-repo/content/6-miscellaneous/healthchecks/_index.md
@@ -42,3 +42,11 @@ Don't forget to map the health endpoint with:
 ```csharp
 app.MapHealthChecks("/healthz");
 ```
+
+## Container Initialization and Health Checks
+
+By default, Cosmos DB containers are created lazily on first repository access. This can cause health checks to fail during startup while containers are being created.
+
+If you're experiencing health check failures during application startup, consider using **eager container initialization** to create containers before the application starts handling requests.
+
+See [Container Initialization](../container-initialization/) for detailed information about lazy vs eager initialization and how to configure it.

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/HealthChecks.csproj
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/HealthChecks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.CosmosRepository\Microsoft.Azure.CosmosRepository.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.CosmosRepository.AspNetCore\Microsoft.Azure.CosmosRepository.AspNetCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/Items/Product.cs
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/Items/Product.cs
@@ -1,0 +1,32 @@
+// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.CosmosRepository;
+
+namespace HealthChecks.Items;
+
+/// <summary>
+/// Simple product item for demonstrating eager container initialization with health checks.
+/// </summary>
+public class Product : Item
+{
+    /// <summary>
+    /// The product name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The product category (used as partition key).
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The product price.
+    /// </summary>
+    public decimal Price { get; set; }
+
+    /// <summary>
+    /// The product description.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+}

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/Program.cs
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/Program.cs
@@ -1,0 +1,61 @@
+// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+using HealthChecks.Items;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+// Add Cosmos Repository with health checks
+builder.Services.AddCosmosRepository(options =>
+{
+    options.DatabaseId = "health-check-demo";
+    options.ContainerPerItemType = true;
+    options.ContainerBuilder.Configure<Product>(containerOptions =>
+    {
+        containerOptions.WithContainer("products");
+        containerOptions.WithPartitionKey("/category");
+    });
+});
+
+// Add health checks for Cosmos Repository
+builder.Services
+    .AddHealthChecks()
+    .AddCosmosRepository();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+WebApplication app = builder.Build();
+
+// Eagerly initialize Cosmos containers before starting the application
+// This ensures containers exist before health checks run
+// Product type is discovered from ContainerBuilder.Configure<Product>() above
+await app.Services.EagerlyInitializeCosmosContainersAsync();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+// Map health check endpoints
+app.MapHealthChecks("/health");
+
+// Simple API endpoints
+app.MapGet("/", () => Results.Redirect("/swagger"))
+    .ExcludeFromDescription();
+
+app.MapGet("/api/products", async (IRepository<Product> repository) =>
+{
+    var products = await repository.GetAsync(p => true);
+    return Results.Ok(products);
+})
+.WithName("GetProducts");
+
+app.MapPost("/api/products", async (Product product, IRepository<Product> repository) =>
+{
+    var created = await repository.CreateAsync(product);
+    return Results.Created($"/api/products/{created.Id}", created);
+})
+.WithName("CreateProduct");
+
+app.Run();

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/README.md
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/README.md
@@ -1,0 +1,91 @@
+# Health Checks Sample
+
+This sample demonstrates the **eager container initialization** feature for Cosmos DB health checks.
+
+## What It Demonstrates
+
+- Using `EagerlyInitializeCosmosContainersAsync()` to pre-create containers at startup
+- Configuring health checks with `AddCosmosRepository()`
+- Ensuring containers exist before health check endpoints become available
+- Preventing health check failures during lazy container initialization
+
+## Key Features
+
+### Eager Initialization
+
+The sample calls `await app.Services.EagerlyInitializeCosmosContainersAsync()` **after `Build()` but before `Run()`**:
+
+```csharp
+var app = builder.Build();
+
+// Containers are created here, before the app starts
+await app.Services.EagerlyInitializeCosmosContainersAsync();
+
+app.Run(); // Health checks only available after containers exist
+```
+
+### Health Check Configuration
+
+Health checks are configured with a simple extension method:
+
+```csharp
+builder.Services
+    .AddHealthChecks()
+    .AddCosmosRepository();
+```
+
+## Running the Sample
+
+### Prerequisites
+
+- Cosmos DB Emulator running locally, or update the connection string in `appsettings.json`
+
+### Steps
+
+1. Start the Cosmos DB Emulator (or configure a real Cosmos DB connection)
+2. Run the application:
+   ```bash
+   dotnet run
+   ```
+3. Check the logs to see eager initialization:
+   ```
+   Eagerly initializing 1 Cosmos DB container(s) for 1 item type(s)...
+   Successfully initialized container 'products' for item type 'Product'
+   Successfully completed eager initialization of 1 Cosmos DB container(s)
+   ```
+4. Navigate to `/health` to verify health checks pass immediately
+5. Use Swagger UI at `/swagger` to test the API endpoints
+
+## Testing Different Scenarios
+
+### Scenario 1: With Eager Initialization (Default)
+
+Leave the code as-is. Health checks will pass immediately on startup.
+
+### Scenario 2: Without Eager Initialization
+
+Comment out the eager initialization line:
+
+```csharp
+// await app.Services.EagerlyInitializeCosmosContainersAsync();
+```
+
+The first health check may fail if containers haven't been created yet through repository operations.
+
+### Scenario 3: Auto-Creation Disabled
+
+Set `IsAutoResourceCreationIfNotExistsEnabled` to `false` in `appsettings.json`. The eager initialization will be skipped (logged as debug), and containers must already exist.
+
+## Endpoints
+
+- `GET /health` - Health check endpoint
+- `GET /api/products` - List all products
+- `POST /api/products` - Create a new product
+- `GET /swagger` - Swagger UI
+
+## Database Created
+
+When you run this sample with `IsAutoResourceCreationIfNotExistsEnabled = true`, you'll see:
+
+- **Database**: `health-check-demo`
+- **Container**: `products` with partition key `/category`

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/appsettings.Development.json
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Azure.CosmosRepository": "Debug"
+    }
+  }
+}

--- a/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/appsettings.json
+++ b/samples/Microsoft.Azure.CosmosRepository.AspNetCore/HealthChecks/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Azure.CosmosRepository": "Debug"
+    }
+  },
+  "AllowedHosts": "*",
+  "RepositoryOptions": {
+    "CosmosConnectionString": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+    "DatabaseId": "health-check-demo",
+    "ContainerPerItemType": true,
+    "IsAutoResourceCreationIfNotExistsEnabled": true
+  }
+}

--- a/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Azure.CosmosRepository.AspNetCore/Extensions/ServiceProviderExtensions.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.CosmosRepository.Options;
+using Microsoft.Azure.CosmosRepository.Providers;
+using Microsoft.Azure.CosmosRepository.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceProvider"/> to support Cosmos Repository operations.
+/// </summary>
+public static class ServiceProviderExtensions
+{
+    /// <summary>
+    /// Eagerly initializes Cosmos DB database and containers before the application starts handling requests.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="assemblies">The assemblies to scan for <see cref="IItem"/> types. Optional. If not provided and no types are explicitly configured, types are discovered from all loaded assemblies.</param>
+    /// <returns>The service provider for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method triggers the creation of the Cosmos DB database and containers that would normally
+    /// be created lazily on first access when <see cref="RepositoryOptions.IsAutoResourceCreationIfNotExistsEnabled"/>
+    /// is enabled.
+    /// </para>
+    /// <para>
+    /// The method discovers item types in two ways:
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>Types explicitly configured via <c>ContainerBuilder.Configure&lt;TItem&gt;()</c></description></item>
+    ///   <item><description>Types discovered by scanning assemblies (when assemblies parameter is provided or no types are explicitly configured)</description></item>
+    /// </list>
+    /// <para>
+    /// <strong>Use this method to:</strong>
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description>Ensure containers exist before health checks run (prevents health check failures during lazy initialization)</description></item>
+    ///   <item><description>Avoid latency on the first request to your application</description></item>
+    ///   <item><description>Fail fast during startup if there are Cosmos DB configuration or connectivity issues</description></item>
+    /// </list>
+    /// <para>
+    /// <strong>Important:</strong> If <see cref="RepositoryOptions.IsAutoResourceCreationIfNotExistsEnabled"/>
+    /// is <c>false</c>, this method does nothing and returns immediately. The database and containers must
+    /// already exist in that case.
+    /// </para>
+    /// <para>
+    /// <strong>Timing:</strong> Call this method after <c>Build()</c> but before <c>Run()</c> in your
+    /// application startup code. Containers will still be created on first use when auto-creation is enabled
+    /// even if this method is not called - this just moves the timing from first-access to startup.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder(args);
+    /// builder.Services.AddCosmosRepository(options =>
+    /// {
+    ///     options.ContainerBuilder.Configure&lt;Product&gt;(c => c.WithContainer("products"));
+    /// });
+    /// builder.Services.AddHealthChecks().AddCosmosRepository();
+    ///
+    /// var app = builder.Build();
+    ///
+    /// // Eagerly initialize containers before starting the application
+    /// // Will discover Product from explicit configuration
+    /// await app.Services.EagerlyInitializeCosmosContainersAsync();
+    ///
+    /// app.MapHealthChecks("/health");
+    /// app.Run();
+    /// </code>
+    /// </example>
+    public static async Task<IServiceProvider> EagerlyInitializeCosmosContainersAsync(
+        this IServiceProvider serviceProvider,
+        params Assembly[]? assemblies)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<ICosmosContainerService>>();
+        var options = serviceProvider.GetRequiredService<IOptions<RepositoryOptions>>();
+
+        if (!options.Value.IsAutoResourceCreationIfNotExistsEnabled)
+        {
+            logger.LogDebug(
+                "Skipping eager Cosmos container initialization because {PropertyName} is false. " +
+                "Database and containers must already exist.",
+                nameof(options.Value.IsAutoResourceCreationIfNotExistsEnabled));
+            return serviceProvider;
+        }
+
+        var itemConfigProvider = serviceProvider.GetRequiredService<ICosmosItemConfigurationProvider>();
+        var containerService = serviceProvider.GetRequiredService<ICosmosContainerService>();
+
+        // Get explicitly configured types from ContainerBuilder
+        var explicitlyConfiguredTypes = options.Value.ContainerOptions
+            .Select(co => co.Type)
+            .ToList();
+
+        List<ItemConfiguration> itemConfigs;
+
+        if (explicitlyConfiguredTypes.Any())
+        {
+            // Use explicitly configured types
+            logger.LogDebug(
+                "Using {Count} explicitly configured item type(s) from ContainerBuilder",
+                explicitlyConfiguredTypes.Count);
+
+            itemConfigs = explicitlyConfiguredTypes
+                .Select(type => itemConfigProvider.GetItemConfiguration(type))
+                .ToList();
+        }
+        else if (assemblies is {Length: > 0})
+        {
+            // Scan provided assemblies
+            logger.LogDebug(
+                "Scanning {Count} provided assemblies for item types",
+                assemblies.Length);
+
+            itemConfigs = itemConfigProvider.GetAllItemConfigurations(assemblies).ToList();
+        }
+        else
+        {
+            // Scan all assemblies as fallback
+            logger.LogDebug(
+                "No explicit configuration or assemblies provided. Scanning all loaded assemblies for item types");
+
+            itemConfigs = itemConfigProvider.GetAllItemConfigurations().ToList();
+        }
+
+        var distinctContainers = itemConfigs.Select(c => c.ContainerName).Distinct().ToList();
+
+        logger.LogInformation(
+            "Eagerly initializing {ContainerCount} Cosmos DB container(s) for {ItemTypeCount} item type(s). " +
+            "Without this call, containers would be created lazily on first repository access.",
+            distinctContainers.Count,
+            itemConfigs.Count);
+
+        foreach (var config in itemConfigs)
+        {
+            try
+            {
+                await containerService.GetContainerAsync([config.Type]);
+                logger.LogDebug(
+                    "Successfully initialized container '{ContainerName}' for item type '{ItemType}'",
+                    config.ContainerName,
+                    config.Type.Name);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to initialize container '{ContainerName}' for item type '{ItemType}'. " +
+                    "Error: {ErrorMessage}",
+                    config.ContainerName,
+                    config.Type.Name,
+                    ex.Message);
+                throw;
+            }
+        }
+
+        logger.LogInformation(
+            "Successfully completed eager initialization of {ContainerCount} Cosmos DB container(s)",
+            distinctContainers.Count);
+
+        return serviceProvider;
+    }
+}


### PR DESCRIPTION
Addresses #527 

Adds a new `EagerlyInitializeCosmosContainersAsync` extension which creates containers **at application startup** before any requests are handled.

This allows developers using this library in CI pipelines to wait for DB readiness before handling any requests (specifically health checks).

- Added new extension method for eager DB initialisation
- Added sample app to prove functionality
- Updated docs to explain use cases

> Note, I skipped units test as this is orchestration code, and I wasn't sure if they would add much value.