### PR TITLE
Read lease container options from current value

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/ChangeFeed/Providers/DefaultLeaseContainerProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/ChangeFeed/Providers/DefaultLeaseContainerProvider.cs
@@ -7,7 +7,7 @@ class DefaultLeaseContainerProvider : ILeaseContainerProvider
 {
     private readonly ICosmosClientProvider _cosmosClientProvider;
     private readonly Lazy<Task<Container>> _lazyContainer;
-    private readonly RepositoryOptions _repositoryOptions;
+    private readonly IOptionsMonitor<RepositoryOptions> _optionsMonitor;
     private const string LeaseContainerName = "lease";
     private const string LeastContainerPartitionKey = "/id";
 
@@ -15,8 +15,8 @@ class DefaultLeaseContainerProvider : ILeaseContainerProvider
         ICosmosClientProvider cosmosClientProvider,
         IOptionsMonitor<RepositoryOptions> optionsMonitor)
     {
-        _repositoryOptions = optionsMonitor.CurrentValue;
         _cosmosClientProvider = cosmosClientProvider;
+        _optionsMonitor = optionsMonitor;
         _lazyContainer = new Lazy<Task<Container>>(BuildLeaseContainer);
     }
 
@@ -25,17 +25,19 @@ class DefaultLeaseContainerProvider : ILeaseContainerProvider
 
     private async Task<Container> BuildLeaseContainer()
     {
+        RepositoryOptions repositoryOptions = _optionsMonitor.CurrentValue;
+
         Database database =
-            _repositoryOptions.IsAutoResourceCreationIfNotExistsEnabled
+            repositoryOptions.IsAutoResourceCreationIfNotExistsEnabled
                 ? await _cosmosClientProvider.UseClientAsync(
-                        client => client.CreateDatabaseIfNotExistsAsync(_repositoryOptions.DatabaseId))
+                        client => client.CreateDatabaseIfNotExistsAsync(repositoryOptions.DatabaseId))
                     .ConfigureAwait(false)
                 : await _cosmosClientProvider.UseClientAsync(
-                        client => Task.FromResult(client.GetDatabase(_repositoryOptions.DatabaseId)))
+                        client => Task.FromResult(client.GetDatabase(repositoryOptions.DatabaseId)))
                     .ConfigureAwait(false);
 
         Container container =
-            _repositoryOptions.IsAutoResourceCreationIfNotExistsEnabled
+            repositoryOptions.IsAutoResourceCreationIfNotExistsEnabled
                 ? await database.CreateContainerIfNotExistsAsync(LeaseContainerName, LeastContainerPartitionKey)
                     .ConfigureAwait(false)
                 : await Task.FromResult(database.GetContainer(LeaseContainerName));

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/ChangeFeed/DefaultLeaseContainerProviderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/ChangeFeed/DefaultLeaseContainerProviderTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) David Pine. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.CosmosRepositoryTests.ChangeFeed;
+
+public class DefaultLeaseContainerProviderTests
+{
+    private static ILeaseContainerProvider CreateSut(
+        ICosmosClientProvider cosmosClientProvider,
+        Func<RepositoryOptions> getCurrentOptions)
+    {
+        Mock<IOptionsMonitor<RepositoryOptions>> monitor = new();
+        monitor.SetupGet(options => options.CurrentValue)
+            .Returns(getCurrentOptions);
+
+        return new DefaultLeaseContainerProvider(cosmosClientProvider, monitor.Object);
+    }
+
+    [Fact]
+    public async Task GetLeaseContainerAsync_WhenOptionsChangeBeforeFirstInvocation_UsesUpdatedOptionsForExistingResources()
+    {
+        // Arrange
+        RepositoryOptions initialOptions = CreateOptions("initial-db", true);
+        RepositoryOptions updatedOptions = CreateOptions("updated-db", false);
+        Mock<CosmosClient> cosmosClient = new();
+        Mock<Database> database = new();
+        Mock<Container> container = new();
+        RepositoryOptions currentOptions = initialOptions;
+        ILeaseContainerProvider sut = CreateSut(
+            new TestCosmosClientProvider(cosmosClient.Object),
+            () => currentOptions);
+
+        cosmosClient.Setup(client => client.GetDatabase(updatedOptions.DatabaseId))
+            .Returns(database.Object);
+
+        database.Setup(value => value.GetContainer("lease"))
+            .Returns(container.Object);
+
+        currentOptions = updatedOptions;
+
+        // Act
+        Container leaseContainer = await sut.GetLeaseContainerAsync();
+
+        // Assert
+        Assert.Equal(container.Object, leaseContainer);
+        cosmosClient.Verify(client => client.GetDatabase(updatedOptions.DatabaseId), Times.Once);
+        cosmosClient.Verify(client => client.GetDatabase(initialOptions.DatabaseId), Times.Never);
+        cosmosClient.Verify(
+            client => client.CreateDatabaseIfNotExistsAsync(It.IsAny<string>(), (int?)null, null, CancellationToken.None),
+            Times.Never);
+        database.Verify(value => value.GetContainer("lease"), Times.Once);
+        database.Verify(
+            value => value.CreateContainerIfNotExistsAsync(It.IsAny<string>(), It.IsAny<string>(), (int?)null, null, CancellationToken.None),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetLeaseContainerAsync_WhenOptionsChangeBeforeFirstInvocation_UsesUpdatedOptionsForAutoCreatedResources()
+    {
+        // Arrange
+        RepositoryOptions initialOptions = CreateOptions("initial-db", false);
+        RepositoryOptions updatedOptions = CreateOptions("updated-db", true);
+        Mock<CosmosClient> cosmosClient = new();
+        Mock<Database> database = new();
+        Mock<Container> container = new();
+        Mock<DatabaseResponse> databaseResponse = new();
+        Mock<ContainerResponse> containerResponse = new();
+        RepositoryOptions currentOptions = initialOptions;
+        ILeaseContainerProvider sut = CreateSut(
+            new TestCosmosClientProvider(cosmosClient.Object),
+            () => currentOptions);
+
+        databaseResponse.Setup(value => value.Database)
+            .Returns(database.Object);
+
+        containerResponse.Setup(value => value.Container)
+            .Returns(container.Object);
+
+        cosmosClient.Setup(client =>
+                client.CreateDatabaseIfNotExistsAsync(updatedOptions.DatabaseId, (int?)null, null, CancellationToken.None))
+            .ReturnsAsync(databaseResponse.Object);
+
+        database.Setup(value =>
+                value.CreateContainerIfNotExistsAsync("lease", "/id", (int?)null, null, CancellationToken.None))
+            .ReturnsAsync(containerResponse.Object);
+
+        currentOptions = updatedOptions;
+
+        // Act
+        Container leaseContainer = await sut.GetLeaseContainerAsync();
+
+        // Assert
+        Assert.Equal(container.Object, leaseContainer);
+        cosmosClient.Verify(client => client.GetDatabase(It.IsAny<string>()), Times.Never);
+        cosmosClient.Verify(
+            client => client.CreateDatabaseIfNotExistsAsync(updatedOptions.DatabaseId, (int?)null, null, CancellationToken.None),
+            Times.Once);
+        cosmosClient.Verify(
+            client => client.CreateDatabaseIfNotExistsAsync(initialOptions.DatabaseId, (int?)null, null, CancellationToken.None),
+            Times.Never);
+        database.Verify(value => value.GetContainer(It.IsAny<string>()), Times.Never);
+        database.Verify(
+            value => value.CreateContainerIfNotExistsAsync("lease", "/id", (int?)null, null, CancellationToken.None),
+            Times.Once);
+    }
+
+    private static RepositoryOptions CreateOptions(string databaseId, bool autoCreate) =>
+        new()
+        {
+            DatabaseId = databaseId,
+            IsAutoResourceCreationIfNotExistsEnabled = autoCreate
+        };
+}


### PR DESCRIPTION
## Summary
- update DefaultLeaseContainerProvider to read IOptionsMonitor<RepositoryOptions>.CurrentValue when the lazy lease container is first built
- add regression coverage for both existing-resource and auto-create lease container paths

## Testing
- dotnet build .\Microsoft.Azure.CosmosRepository.sln -nologo -clp:Summary --verbosity minimal
- dotnet test .\tests\Microsoft.Azure.CosmosRepositoryTests\Microsoft.Azure.CosmosRepositoryTests.csproj --no-build -nologo -clp:Summary --verbosity minimal

## Compatibility
- This is a non-breaking bug fix.
- No public APIs changed.
- The behavior change is limited to keeping lease-container creation aligned with the current options pipeline value.