### PR TITLE
Validate shared container partition key paths

### DIFF
--- a/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosPartitionKeyPathProvider.cs
+++ b/src/Microsoft.Azure.CosmosRepository/Providers/DefaultCosmosPartitionKeyPathProvider.cs
@@ -15,9 +15,33 @@ class DefaultCosmosPartitionKeyPathProvider(IOptions<RepositoryOptions> options)
 
     public string GetPartitionKeyPath(Type itemType)
     {
-        Type attributeType = typeof(PartitionKeyPathAttribute);
-
         ContainerOptionsBuilder? optionsBuilder = _options.Value.GetContainerOptions(itemType);
+        string partitionKeyPath = GetPartitionKeyPath(itemType, optionsBuilder);
+
+        if (optionsBuilder is not null)
+        {
+            foreach (ContainerOptionsBuilder sharedContainerOptions in _options.Value.GetContainerSharedContainerOptions(itemType))
+            {
+                string sharedPartitionKeyPath = GetPartitionKeyPath(sharedContainerOptions.Type, sharedContainerOptions);
+
+                if (string.Equals(sharedPartitionKeyPath, partitionKeyPath, StringComparison.Ordinal) is false)
+                {
+                    string containerName = optionsBuilder.Name ?? _options.Value.ContainerId;
+
+                    throw new InvalidOperationException(
+                        $"The container {containerName} has conflicting partition key paths. " +
+                        $"({optionsBuilder.Type.Name}->{partitionKeyPath} vs " +
+                        $"{sharedContainerOptions.Type.Name}->{sharedPartitionKeyPath}).");
+                }
+            }
+        }
+
+        return partitionKeyPath;
+    }
+
+    private static string GetPartitionKeyPath(Type itemType, ContainerOptionsBuilder? optionsBuilder)
+    {
+        Type attributeType = typeof(PartitionKeyPathAttribute);
 
         if (optionsBuilder is { } && string.IsNullOrWhiteSpace(optionsBuilder.PartitionKey) is false)
         {

--- a/tests/Microsoft.Azure.CosmosRepositoryTests/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
+++ b/tests/Microsoft.Azure.CosmosRepositoryTests/Providers/DefaultCosmosPartitionKeyPathProviderTests.cs
@@ -48,6 +48,41 @@ public class DefaultCosmosPartitionKeyPathProviderTests
         Assert.Equal("/pickles", path);
         Assert.Equal("[\"Hey, where's the chips?!\"]", new Cosmos.PartitionKey(((IItem)new PickleChipsItem()).PartitionKey).ToString());
     }
+
+    [Fact]
+    public void CosmosPartitionKeyPathProviderItemsThatShareAContainerWithEqualValuesReturnPath()
+    {
+        _repositoryOptions.ContainerBuilder.Configure<Person>(options =>
+            options.WithContainer("people").WithPartitionKey("/email"));
+
+        _repositoryOptions.ContainerBuilder.Configure<AnotherPerson>(options =>
+            options.WithContainer("people"));
+
+        ICosmosPartitionKeyPathProvider provider = new DefaultCosmosPartitionKeyPathProvider(_options.Object);
+
+        string path = provider.GetPartitionKeyPath<Person>();
+
+        Assert.Equal("/email", path);
+    }
+
+    [Fact]
+    public void CosmosPartitionKeyPathProviderItemsThatShareAContainerWithConflictingValuesThrow()
+    {
+        _repositoryOptions.ContainerBuilder.Configure<Person>(options =>
+            options.WithContainer("people").WithPartitionKey("/firstName"));
+
+        _repositoryOptions.ContainerBuilder.Configure<AnotherPerson>(options =>
+            options.WithContainer("people"));
+
+        ICosmosPartitionKeyPathProvider provider = new DefaultCosmosPartitionKeyPathProvider(_options.Object);
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(() => provider.GetPartitionKeyPath<Person>());
+
+        Assert.Contains("partition key paths", exception.Message);
+        Assert.Contains("/firstName", exception.Message);
+        Assert.Contains("/email", exception.Message);
+    }
 }
 
 [PartitionKeyPath("/email")]


### PR DESCRIPTION
## Summary
- update DefaultCosmosPartitionKeyPathProvider to fail fast when item types that share a container resolve to conflicting partition key paths
- add regression coverage for both matching and conflicting shared-container partition key paths

## Testing
- dotnet test .\tests\Microsoft.Azure.CosmosRepositoryTests\Microsoft.Azure.CosmosRepositoryTests.csproj --no-restore -nologo -clp:Summary --verbosity minimal

## Compatibility
- This is a non-breaking bug fix.
- No public APIs changed.
- The behavior change is limited to surfacing invalid shared-container partition key configurations earlier.